### PR TITLE
change: get dimensions for aq.ArrayVar automatically

### DIFF
--- a/src/autoqasm/types/types.py
+++ b/src/autoqasm/types/types.py
@@ -96,7 +96,9 @@ class Range(oqpy.Range):
 
 
 class ArrayVar(oqpy.ArrayVar):
-    def __init__(self, *args, annotations: str | Iterable[str] | None = None, **kwargs):
+    def __init__(
+        self, init_expression, *args, annotations: str | Iterable[str] | None = None, **kwargs
+    ):
         if (
             program.get_program_conversion_context().subroutines_processing
             or not program.get_program_conversion_context().at_function_root_scope
@@ -105,11 +107,13 @@ class ArrayVar(oqpy.ArrayVar):
                 "Arrays may only be declared at the root scope of an AutoQASM main function."
             )
 
-        if not args:
-            raise errors.InvalidArrayDeclaration("init_expression must at least be provided.")
-        dimensions = [len(args[0])]
+        dimensions = [len(init_expression)]
         super(ArrayVar, self).__init__(
-            *args, annotations=make_annotations_list(annotations), dimensions=dimensions, **kwargs
+            init_expression=init_expression,
+            *args,
+            annotations=make_annotations_list(annotations),
+            dimensions=dimensions,
+            **kwargs,
         )
         self.name = program.get_program_conversion_context().next_var_name(oqpy.ArrayVar)
 

--- a/src/autoqasm/types/types.py
+++ b/src/autoqasm/types/types.py
@@ -104,8 +104,12 @@ class ArrayVar(oqpy.ArrayVar):
             raise errors.InvalidArrayDeclaration(
                 "Arrays may only be declared at the root scope of an AutoQASM main function."
             )
+
+        if not args:
+            raise errors.InvalidArrayDeclaration("init_expression must at least be provided.")
+        dimensions = [len(args[0])]
         super(ArrayVar, self).__init__(
-            *args, annotations=make_annotations_list(annotations), **kwargs
+            *args, annotations=make_annotations_list(annotations), dimensions=dimensions, **kwargs
         )
         self.name = program.get_program_conversion_context().next_var_name(oqpy.ArrayVar)
 

--- a/src/autoqasm/types/types.py
+++ b/src/autoqasm/types/types.py
@@ -97,7 +97,11 @@ class Range(oqpy.Range):
 
 class ArrayVar(oqpy.ArrayVar):
     def __init__(
-        self, init_expression, *args, annotations: str | Iterable[str] | None = None, **kwargs
+        self,
+        init_expression: Iterable,
+        *args,
+        annotations: str | Iterable[str] | None = None,
+        **kwargs,
     ):
         if (
             program.get_program_conversion_context().subroutines_processing
@@ -106,6 +110,9 @@ class ArrayVar(oqpy.ArrayVar):
             raise errors.InvalidArrayDeclaration(
                 "Arrays may only be declared at the root scope of an AutoQASM main function."
             )
+
+        if not isinstance(init_expression, Iterable):
+            raise errors.InvalidArrayDeclaration("init_expression must be an iterable type.")
 
         dimensions = [len(init_expression)]
         super(ArrayVar, self).__init__(

--- a/test/unit_tests/autoqasm/test_types.py
+++ b/test/unit_tests/autoqasm/test_types.py
@@ -186,9 +186,9 @@ def test_declare_array():
 
     @aq.main
     def declare_array():
-        a = aq.ArrayVar([1, 2, 3], base_type=aq.IntVar, dimensions=[3])
+        a = aq.ArrayVar([1, 2, 3], base_type=aq.IntVar)
         a[0] = 11
-        b = aq.ArrayVar([4, 5, 6], base_type=aq.IntVar, dimensions=[3])
+        b = aq.ArrayVar([4, 5, 6], base_type=aq.IntVar)
         b[2] = 14
         b = a
 
@@ -207,8 +207,8 @@ def test_invalid_array_assignment():
 
     @aq.main
     def invalid():
-        a = aq.ArrayVar([1, 2, 3], base_type=aq.IntVar, dimensions=[3])
-        b = aq.ArrayVar([4, 5], base_type=aq.IntVar, dimensions=[2])
+        a = aq.ArrayVar([1, 2, 3], base_type=aq.IntVar)
+        b = aq.ArrayVar([4, 5], base_type=aq.IntVar)
         a = b  # noqa: F841
 
     with pytest.raises(aq.errors.InvalidAssignmentStatement):
@@ -221,7 +221,7 @@ def test_declare_array_in_local_scope():
     @aq.main
     def declare_array():
         if aq.BoolVar(True):
-            _ = aq.ArrayVar([1, 2, 3], base_type=aq.IntVar, dimensions=[3])
+            _ = aq.ArrayVar([1, 2, 3], base_type=aq.IntVar)
 
     with pytest.raises(aq.errors.InvalidArrayDeclaration):
         declare_array.build()
@@ -236,7 +236,7 @@ def test_declare_array_in_subroutine():
 
     @aq.subroutine
     def declare_array():
-        _ = aq.ArrayVar([1, 2, 3], dimensions=[3])
+        _ = aq.ArrayVar([1, 2, 3])
 
     with pytest.raises(aq.errors.InvalidArrayDeclaration):
         main.build()
@@ -383,7 +383,7 @@ def test_map_array():
 
     @aq.main
     def main():
-        a = aq.ArrayVar([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dimensions=[10])
+        a = aq.ArrayVar([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
         annotation_test(a)
 
     with pytest.raises(aq.errors.ParameterTypeError):
@@ -724,3 +724,21 @@ def test_param_array_list_missing_arg():
 
     with pytest.raises(aq.errors.ParameterTypeError):
         main.build()
+
+
+def test_ArrayVar_does_not_need_dimensions_argument():
+    @aq.main
+    def declare_array():
+        aq.ArrayVar([1, 2, 3], base_type=aq.IntVar, dimensions=[3])
+
+    with pytest.raises(TypeError):
+        declare_array.build()
+
+
+def test_ArrayVar_requires_init_expression():
+    @aq.main
+    def declare_array():
+        aq.ArrayVar()
+
+    with pytest.raises(aq.errors.InvalidArrayDeclaration):
+        declare_array.build()

--- a/test/unit_tests/autoqasm/test_types.py
+++ b/test/unit_tests/autoqasm/test_types.py
@@ -744,6 +744,15 @@ def test_array_requires_init_expression():
         declare_array.build()
 
 
+def test_array_init_expression_type():
+    @aq.main
+    def declare_array():
+        aq.ArrayVar(1)
+
+    with pytest.raises(aq.errors.InvalidArrayDeclaration):
+        declare_array.build()
+
+
 def test_array_supports_multidimensional_arrays():
     @aq.main
     def declare_array():

--- a/test/unit_tests/autoqasm/test_types.py
+++ b/test/unit_tests/autoqasm/test_types.py
@@ -726,7 +726,7 @@ def test_param_array_list_missing_arg():
         main.build()
 
 
-def test_ArrayVar_does_not_need_dimensions_argument():
+def test_array_does_not_accept_dimensions_argument():
     @aq.main
     def declare_array():
         aq.ArrayVar([1, 2, 3], base_type=aq.IntVar, dimensions=[3])
@@ -735,10 +735,21 @@ def test_ArrayVar_does_not_need_dimensions_argument():
         declare_array.build()
 
 
-def test_ArrayVar_requires_init_expression():
+def test_array_requires_init_expression():
     @aq.main
     def declare_array():
         aq.ArrayVar()
 
-    with pytest.raises(aq.errors.InvalidArrayDeclaration):
+    with pytest.raises(TypeError):
         declare_array.build()
+
+
+def test_array_supports_multidimensional_arrays():
+    @aq.main
+    def declare_array():
+        aq.ArrayVar([[1, 2], [3, 4]])
+
+    expected = """OPENQASM 3.0;
+array[int[32], 2, 2] a = {{1, 2}, {3, 4}};"""
+
+    declare_array.build().to_ir() == expected


### PR DESCRIPTION
*Issue #13:*

*Description of changes:*

- In the definition of `ArrayVar` in `types.py`, the `dimensions` keyword argument is no longer required but inferred from the initial expression. The initial expression, however, becomes a necessary argument following the comments made on the issue.
- `args[0]` is used because `_ClassicalVar` in `oqpy`'s `ArrayVar` suggests `init_expression` is the first argument.

*Testing done:* Yes.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/amazon-braket/autoqasm/blob/main/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/autoqasm/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/autoqasm/blob/main/README.md) and [API docs](https://github.com/amazon-braket/autoqasm/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)
    - Perhaps not required since the high-level interface only contains `args` and `kwargs`, which remain unchanged? 

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
    - Not applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
