### PR TITLE
fix: fix issue with kwargs while calling subroutine

### DIFF
--- a/test/unit_tests/autoqasm/test_api.py
+++ b/test/unit_tests/autoqasm/test_api.py
@@ -1240,3 +1240,29 @@ h __qubits__[1];
 h __qubits__[2];
 h __qubits__[3];"""
     assert main.build().to_ir() == expected_ir
+
+
+def test_subroutine_call_with_kwargs():
+    """Test that subroutine call works with keyword arguments"""
+
+    @aq.subroutine
+    def test(a: int, b: int) -> None:
+        aq.instructions.h(a)
+        aq.instructions.h(b)
+
+    @aq.main(num_qubits=2)
+    def main():
+        test(0, b=1)  # Test with one keyword argument
+        test(a=2, b=3)  # Test with keyword argument
+        test(b=5, a=4)  # Test with keyword argument in any order
+
+    expected = """OPENQASM 3.0;
+def test(int[32] a, int[32] b) {
+    h __qubits__[a];
+    h __qubits__[b];
+}
+qubit[2] __qubits__;
+test(0, 1);
+test(2, 3);
+test(4, 5);"""
+    assert main.build().to_ir() == expected


### PR DESCRIPTION
*Issue #11 :*

*Description of changes:*

- Convert kwargs to args to support keyword args while calling the subroutine function

*Testing done:* Yes

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/autoqasm/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/autoqasm/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/autoqasm/blob/main/README.md) and [API docs](https://github.com/amazon-braket/autoqasm/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
