### PR TITLE
fix: mangle OpenQASM keywords

### DIFF
--- a/src/autoqasm/api.py
+++ b/src/autoqasm/api.py
@@ -33,7 +33,7 @@ import autoqasm.transpiler as aq_transpiler
 import autoqasm.types as aq_types
 from autoqasm import errors
 from autoqasm.program.gate_calibrations import GateCalibration
-from autoqasm.reserved_keywords import is_reserved_keyword
+from autoqasm.reserved_keywords import sanitize_parameter_name
 from autoqasm.types import QubitIdentifierType as Qubit
 
 
@@ -326,9 +326,8 @@ def _convert_subroutine(
 
         # Iterate over list of dictionary keys to avoid runtime error
         for key in list(kwargs):
-            is_keyword, new_name = is_reserved_keyword(key)
-            if is_keyword:
-                kwargs[new_name] = kwargs.pop(key)
+            new_name = sanitize_parameter_name(key)
+            kwargs[new_name] = kwargs.pop(key)
 
         if f not in program_conversion_context.subroutines_processing:
             # Mark that we are starting to process this function to short-circuit recursion
@@ -453,13 +452,13 @@ def _wrap_for_oqpy_subroutine(f: Callable, options: converter.ConversionOptions)
                 f'Parameter "{param.name}" for subroutine "{_func.__name__}" '
                 "is missing a required type hint."
             )
+
         # Check whether 'param.name' is a reserved keyword
-        is_keyword, _name = is_reserved_keyword(param.name)
-        if is_keyword:
-            _func.__annotations__.pop(param.name)
+        new_name = sanitize_parameter_name(param.name)
+        _func.__annotations__.pop(param.name)
 
         new_param = inspect.Parameter(
-            name=_name,
+            name=new_name,
             kind=param.kind,
             annotation=aq_types.map_parameter_type(param.annotation),
         )

--- a/src/autoqasm/reserved_keywords.py
+++ b/src/autoqasm/reserved_keywords.py
@@ -57,7 +57,7 @@ reserved_keywords = {
 }
 
 
-def is_reserved_keyword(name: str) -> bool:
+def is_reserved_keyword(name: str) -> tuple[bool, str]:
     """
     Method to check whether or not 'name' is a reserved keyword
 

--- a/src/autoqasm/reserved_keywords.py
+++ b/src/autoqasm/reserved_keywords.py
@@ -1,0 +1,74 @@
+# Permalink: https://github.com/openqasm/openqasm/blob/main/source/grammar/qasm3Lexer.g4
+reserved_keywords = {
+    "angle",
+    "array",
+    "barrier",
+    "bit",
+    "bool",
+    "box",
+    "cal",
+    "case",
+    "complex",
+    "const",
+    "creg",
+    "ctrl",
+    "default",
+    "defcal",
+    "defcalgrammar",
+    "delay",
+    "duration",
+    "durationof",
+    "end",
+    "euler",
+    "extern",
+    "false",
+    "float",
+    "frame",
+    "gate",
+    "gphase",
+    "im",
+    "include",
+    "input",
+    "int",
+    "inv",
+    "let",
+    "OPENQASM",
+    "measure",
+    "mutable",
+    "negctrl",
+    "output",
+    "pi",
+    "port",
+    "pragma",
+    "qreg",
+    "qubit",
+    "readonly",
+    "reset",
+    "return",
+    "sizeof",
+    "stretch",
+    "switch",
+    "tau",
+    "true",
+    "U",
+    "uint",
+    "void",
+    "waveform",
+}
+
+
+def is_reserved_keyword(name: str) -> bool:
+    """
+    Method to check whether or not 'name' is a reserved keyword
+
+    Args:
+        name (str): Name of the variable to be checked
+
+    Returns:
+        tuple[bool, str]: Returns a tuple containing a boolean indicating
+        whether the input 'name' is a reserved keyword and the modified name.
+        If 'name' is a reserved keyword, the modified name has an underscore
+        ('_') appended to it; otherwise, it remains unchanged.
+    """
+    is_keyword = name in reserved_keywords
+    return (is_keyword, f"{name}_" if is_keyword else name)

--- a/src/autoqasm/reserved_keywords.py
+++ b/src/autoqasm/reserved_keywords.py
@@ -1,5 +1,9 @@
-# Copied from: https://github.com/openqasm/openqasm/blob/main/source/grammar/qasm3Lexer.g4
+# Copied from:
+# https://github.com/openqasm/openqasm/blob/main/source/grammar/qasm3Lexer.g4
+# https://github.com/openqasm/openpulse-python/blob/main/source/grammar/openpulseLexer.g4
+
 reserved_keywords = {
+    # openQASM keywords
     "angle",
     "array",
     "barrier",
@@ -23,7 +27,6 @@ reserved_keywords = {
     "extern",
     "false",
     "float",
-    "frame",
     "gate",
     "gphase",
     "im",
@@ -38,7 +41,6 @@ reserved_keywords = {
     "negctrl",
     "output",
     "pi",
-    "port",
     "pragma",
     "qreg",
     "qubit",
@@ -53,6 +55,9 @@ reserved_keywords = {
     "U",
     "uint",
     "void",
+    # openpulse keywords
+    "frame",
+    "port",
     "waveform",
 }
 

--- a/src/autoqasm/reserved_keywords.py
+++ b/src/autoqasm/reserved_keywords.py
@@ -1,4 +1,4 @@
-# Permalink: https://github.com/openqasm/openqasm/blob/main/source/grammar/qasm3Lexer.g4
+# Copied from: https://github.com/openqasm/openqasm/blob/main/source/grammar/qasm3Lexer.g4
 reserved_keywords = {
     "angle",
     "array",
@@ -57,18 +57,17 @@ reserved_keywords = {
 }
 
 
-def is_reserved_keyword(name: str) -> tuple[bool, str]:
+def sanitize_parameter_name(name: str) -> str:
     """
-    Method to check whether or not 'name' is a reserved keyword
+    Method to modify the variable name if it is a
+    reserved keyword
 
     Args:
         name (str): Name of the variable to be checked
 
     Returns:
-        tuple[bool, str]: Returns a tuple containing a boolean indicating
-        whether the input 'name' is a reserved keyword and the modified name.
-        If 'name' is a reserved keyword, the modified name has an underscore
-        ('_') appended to it; otherwise, it remains unchanged.
+        str: Returns a modified 'name' that has an underscore ('_') appended to it;
+        otherwise, it returns the original 'name' unchanged
     """
     is_keyword = name in reserved_keywords
-    return (is_keyword, f"{name}_" if is_keyword else name)
+    return f"{name}_" if is_keyword else name

--- a/src/autoqasm/reserved_keywords.py
+++ b/src/autoqasm/reserved_keywords.py
@@ -74,5 +74,4 @@ def sanitize_parameter_name(name: str) -> str:
         str: Returns a modified 'name' that has an underscore ('_') appended to it;
         otherwise, it returns the original 'name' unchanged
     """
-    is_keyword = name in reserved_keywords
-    return f"{name}_" if is_keyword else name
+    return f"{name}_" if name in reserved_keywords else name

--- a/test/unit_tests/autoqasm/test_parameters.py
+++ b/test/unit_tests/autoqasm/test_parameters.py
@@ -401,8 +401,8 @@ def sub(float[64] alpha, float[64] theta) {
     rx(theta) __qubits__[0];
     rx(alpha) __qubits__[1];
 }
-def rx_alpha(int[32] qubit) {
-    rx(alpha) __qubits__[qubit];
+def rx_alpha(int[32] qubit_) {
+    rx(alpha) __qubits__[qubit_];
 }
 float alpha = 0.5;
 float beta = 1.5;
@@ -427,8 +427,8 @@ def test_partial_bind():
     bound_prog = parametric.build().make_bound_program({"beta": np.pi})
 
     expected = """OPENQASM 3.0;
-def rx_alpha(int[32] qubit, float[64] theta) {
-    rx(theta) __qubits__[qubit];
+def rx_alpha(int[32] qubit_, float[64] theta) {
+    rx(theta) __qubits__[qubit_];
 }
 input float alpha;
 float beta = 3.141592653589793;

--- a/test/unit_tests/autoqasm/test_program.py
+++ b/test/unit_tests/autoqasm/test_program.py
@@ -95,8 +95,8 @@ def test_multiprocessing() -> None:
     def expected(scale, angle):
         return (
             """OPENQASM 3.0;
-def circuit(float[64] angle) {
-    rx(angle) __qubits__[0];
+def circuit(float[64] angle_) {
+    rx(angle_) __qubits__[0];
     cnot __qubits__[0], __qubits__[1];
 }
 output bit return_value;

--- a/test/unit_tests/autoqasm/test_types.py
+++ b/test/unit_tests/autoqasm/test_types.py
@@ -309,7 +309,7 @@ def test_map_bool():
         annotation_test(True)
 
     expected = """OPENQASM 3.0;
-def annotation_test(bool input) {
+def annotation_test(bool input_) {
 }
 annotation_test(true);"""
 
@@ -328,7 +328,7 @@ def test_map_int():
         annotation_test(1)
 
     expected = """OPENQASM 3.0;
-def annotation_test(int[32] input) {
+def annotation_test(int[32] input_) {
 }
 annotation_test(1);"""
 
@@ -347,7 +347,7 @@ def test_map_float():
         annotation_test(1.0)
 
     expected = """OPENQASM 3.0;
-def annotation_test(float[64] input) {
+def annotation_test(float[64] input_) {
 }
 annotation_test(1.0);"""
 
@@ -366,7 +366,7 @@ def test_map_qubit():
         annotation_test(1)
 
     expected = """OPENQASM 3.0;
-def annotation_test(qubit input) {
+def annotation_test(qubit input_) {
 }
 qubit[2] __qubits__;
 annotation_test(__qubits__[1]);"""
@@ -403,7 +403,7 @@ def test_map_other():
         annotation_test(a)
 
     expected = """OPENQASM 3.0;
-def annotation_test(bit input) {
+def annotation_test(bit input_) {
 }
 bit a = 1;
 annotation_test(a);"""
@@ -423,7 +423,7 @@ def test_map_other_unnamed_arg():
         annotation_test(aq.BitVar(1))
 
     expected = """OPENQASM 3.0;
-def annotation_test(bit input) {
+def annotation_test(bit input_) {
 }
 bit __bit_0__ = 1;
 annotation_test(__bit_0__);"""


### PR DESCRIPTION
Issue #12

*Description of changes:*
OpenQASM reserved keywords names will be mangled to `<keyword>_`

*Testing done: Yes*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/autoqasm/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/autoqasm/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/autoqasm/blob/main/README.md) and [API docs](https://github.com/amazon-braket/autoqasm/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
