### PR TITLE
fix: Ensure all tests use valid OpenQASM and upgrade to latest Braket SDK

### DIFF
--- a/doc/decorators.md
+++ b/doc/decorators.md
@@ -98,18 +98,18 @@ The body of a function decorated with `@aq.gate_calibration` must only contain p
 The first argument to the `@aq.gate_calibration` decorator must be the gate function that the calibration will be registered to. Concrete values for the qubits and parameters are supplied as keyword arguments to the decorator.
 Every qubit and angle parameter of the gate being implemented must appear either as an argument to the `@aq.gate_calibration` decorator, or as a parameter of the decorated function.
 
-For example, the gate `rx` takes two arguments, target and angle. Each arguments must be either set in the decorator or declared as an input parameter to the decorated function.
+For example, the gate `rx` takes two arguments, target and theta. Each arguments must be either set in the decorator or declared as an input parameter to the decorated function.
 
 ```
 # This calibration only applies to physical qubit zero, so we
 # mark that in the decorator call
 @aq.gate_calibration(implements=rx, target="$0")
-def cal_1(angle: float):
+def cal_1(theta: float):
     # The calibration is applicable for any rotation angle,
     # so we accept it as an input argument
     pulse.barrier("$0")
     pulse.shift_frequency(q0_rf_frame, -321047.14178613486)
-    pulse.play(q0_rf_frame, waveform(angle))
+    pulse.play(q0_rf_frame, waveform(theta))
     pulse.shift_frequency(q0_rf_frame, 321047.14178613486)
     pulse.barrier("$0")
 ```

--- a/examples/6_Customize_gate_calibrations.ipynb
+++ b/examples/6_Customize_gate_calibrations.ipynb
@@ -155,7 +155,7 @@
     "2. Decide the qubits and angles you want to define the calibration.\n",
     "3. Compose a pulse program that defines the calibration.\n",
     "\n",
-    "As an example, let's define the gate calibration of `rx` on qubit `$1` and at angle `pi/2`. We first inspect the definition of the `rx` gate. You can find the definition of gate instructions in the [gate module](https://github.com/amazon-braket/autoqasm/blob/main/src/autoqasm/instructions/gates.py) of AutoQASM. You can also use the Python built-in `help` function to retrieve the definition. A gate calibration for the `rx` gate must fully specify the inputs of the gate, `target` and `angle`."
+    "As an example, let's define the gate calibration of `rx` on qubit `$1` and at angle `pi/2`. We first inspect the definition of the `rx` gate. You can find the definition of gate instructions in the [gate module](https://github.com/amazon-braket/autoqasm/blob/main/src/autoqasm/instructions/gates.py) of AutoQASM. You can also use the Python built-in `help` function to retrieve the definition. A gate calibration for the `rx` gate must fully specify the inputs of the gate, `target` and `theta`."
    ]
   },
   {
@@ -170,12 +170,12 @@
      "text": [
       "Help on function rx in module autoqasm.instructions.gates:\n",
       "\n",
-      "rx(target: Union[int, str, braket.registers.qubit.Qubit, oqpy.classical_types._ClassicalVar, oqpy.base.OQPyExpression, oqpy.quantum_types.Qubit], angle: Union[float, braket.parametric.free_parameter_expression.FreeParameterExpression, oqpy.classical_types._ClassicalVar], **kwargs) -> None\n",
+      "rx(target: Union[int, str, braket.registers.qubit.Qubit, oqpy.classical_types._ClassicalVar, oqpy.base.OQPyExpression, oqpy.quantum_types.Qubit], theta: Union[float, braket.parametric.free_parameter_expression.FreeParameterExpression, oqpy.classical_types._ClassicalVar], **kwargs) -> None\n",
       "    X-axis rotation gate.\n",
       "    \n",
       "    Args:\n",
       "        target (QubitIdentifierType): Target qubit.\n",
-      "        angle (GateParameterType): Rotation angle in radians.\n",
+      "        theta (GateParameterType): Rotation angle in radians.\n",
       "\n"
      ]
     }
@@ -189,7 +189,7 @@
    "id": "a1189626",
    "metadata": {},
    "source": [
-    "To specify fixed values for the parameters `target` and `angle`, we set the values through keyword arguments of the decorator. The pulse implementation for the gate calibration is in the body of the `my_rx_cal` function decorated by `@aq.gate_calibration`. In the example in the next cell, we want to experiment with offsetting the frequency of the pulse by 100 Hz away from the hardware provider's implementation. The gate calibration `my_rx_cal` recreates the hardware provider's implementation but with an offset in the frequency."
+    "To specify fixed values for the parameters `target` and `theta`, we set the values through keyword arguments of the decorator. The pulse implementation for the gate calibration is in the body of the `my_rx_cal` function decorated by `@aq.gate_calibration`. In the example in the next cell, we want to experiment with offsetting the frequency of the pulse by 100 Hz away from the hardware provider's implementation. The gate calibration `my_rx_cal` recreates the hardware provider's implementation but with an offset in the frequency."
    ]
   },
   {
@@ -205,7 +205,7 @@
     "q0_rf_frame = device.frames[\"q0_rf_frame\"]\n",
     "\n",
     "\n",
-    "@aq.gate_calibration(implements=rx, target=\"$0\", angle=np.pi / 2)\n",
+    "@aq.gate_calibration(implements=rx, target=\"$0\", theta=np.pi / 2)\n",
     "def my_rx_cal():\n",
     "    pulse.barrier(\"$0\")\n",
     "    pulse.shift_frequency(q0_rf_frame, -321047.14178613486 - 100)\n",
@@ -299,7 +299,7 @@
    "id": "f038b8c8",
    "metadata": {},
    "source": [
-    "You can also define a gate calibration with variable parameters. Variable parameters are used in the body of the decorated function. The variable parameters must be arguments of the decorated Python function, instead of being arguments to the decorator `@aq.gate_calibration`. The variable parameters must have a type hint of either `aq.Qubit` for qubits or `float` for angles. Let's define another gate calibration with a variable parameter. This time, we define a calibration for the `rz` gate on qubit `$1` and a variable angle `angle`."
+    "You can also define a gate calibration with variable parameters. Variable parameters are used in the body of the decorated function. The variable parameters must be arguments of the decorated Python function, instead of being arguments to the decorator `@aq.gate_calibration`. The variable parameters must have a type hint of either `aq.Qubit` for qubits or `float` for angles. Let's define another gate calibration with a variable parameter. This time, we define a calibration for the `rz` gate on qubit `$1` and a variable angle `theta`."
    ]
   },
   {
@@ -313,9 +313,9 @@
     "\n",
     "\n",
     "@aq.gate_calibration(implements=rz, target=\"$1\")\n",
-    "def my_rz_cal(angle: float):\n",
+    "def my_rz_cal(theta: float):\n",
     "    pulse.barrier(\"$1\")\n",
-    "    pulse.shift_frequency(q1_rf_frame, -1.0 * angle)\n",
+    "    pulse.shift_frequency(q1_rf_frame, -1.0 * theta)\n",
     "    pulse.barrier(\"$1\")"
    ]
   },
@@ -348,9 +348,9 @@
       "    shift_frequency(q0_rf_frame, 321147.14178613486);\n",
       "    barrier $0;\n",
       "}\n",
-      "defcal rz(angle[32] angle) $1 {\n",
+      "defcal rz(angle[32] theta) $1 {\n",
       "    barrier $1;\n",
-      "    shift_frequency(q1_rf_frame, -1.0 * angle);\n",
+      "    shift_frequency(q1_rf_frame, -1.0 * theta);\n",
       "    barrier $1;\n",
       "}\n",
       "rx(1.5707963267948966) $0;\n",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     packages=find_namespace_packages(where="src", exclude=("test",)),
     package_dir={"": "src"},
     install_requires=[
-        "amazon-braket-sdk==1.81.0",
+        "amazon-braket-sdk>=1.87.1",
         "amazon-braket-default-simulator>=1.23.2",
         "oqpy~=0.3.5",
         "diastatic-malt",

--- a/src/autoqasm/instructions/gates.py
+++ b/src/autoqasm/instructions/gates.py
@@ -60,7 +60,7 @@ def cnot(
 def cphaseshift(
     control: QubitIdentifierType,
     target: QubitIdentifierType,
-    angle: GateParameterType,
+    theta: GateParameterType,
     **kwargs,
 ) -> None:
     """Controlled phase shift gate.
@@ -68,16 +68,16 @@ def cphaseshift(
     Args:
         control (QubitIdentifierType): Control qubit.
         target (QubitIdentifierType): Target qubit.
-        angle (GateParameterType): Rotation angle in radians.
+        theta (GateParameterType): Rotation angle in radians.
 
     """
-    _qubit_instruction("cphaseshift", [control, target], angle, **kwargs)
+    _qubit_instruction("cphaseshift", [control, target], theta, **kwargs)
 
 
 def cphaseshift00(
     control: QubitIdentifierType,
     target: QubitIdentifierType,
-    angle: GateParameterType,
+    theta: GateParameterType,
     **kwargs,
 ) -> None:
     """Controlled phase shift gate for phasing the \\|00> state.
@@ -85,16 +85,16 @@ def cphaseshift00(
     Args:
         control (QubitIdentifierType): Control qubit.
         target (QubitIdentifierType): Target qubit.
-        angle (GateParameterType): Rotation angle in radians.
+        theta (GateParameterType): Rotation angle in radians.
 
     """
-    _qubit_instruction("cphaseshift00", [control, target], angle, **kwargs)
+    _qubit_instruction("cphaseshift00", [control, target], theta, **kwargs)
 
 
 def cphaseshift01(
     control: QubitIdentifierType,
     target: QubitIdentifierType,
-    angle: GateParameterType,
+    theta: GateParameterType,
     **kwargs,
 ) -> None:
     """Controlled phase shift gate for phasing the \\|01> state.
@@ -102,16 +102,16 @@ def cphaseshift01(
     Args:
         control (QubitIdentifierType): Control qubit.
         target (QubitIdentifierType): Target qubit.
-        angle (GateParameterType): Rotation angle in radians.
+        theta (GateParameterType): Rotation angle in radians.
 
     """
-    _qubit_instruction("cphaseshift01", [control, target], angle, **kwargs)
+    _qubit_instruction("cphaseshift01", [control, target], theta, **kwargs)
 
 
 def cphaseshift10(
     control: QubitIdentifierType,
     target: QubitIdentifierType,
-    angle: GateParameterType,
+    theta: GateParameterType,
     **kwargs,
 ) -> None:
     """Controlled phase shift gate for phasing the \\|10> state.
@@ -119,10 +119,10 @@ def cphaseshift10(
     Args:
         control (QubitIdentifierType): Control qubit.
         target (QubitIdentifierType): Target qubit.
-        angle (GateParameterType): Rotation angle in radians.
+        theta (GateParameterType): Rotation angle in radians.
 
     """
-    _qubit_instruction("cphaseshift10", [control, target], angle, **kwargs)
+    _qubit_instruction("cphaseshift10", [control, target], theta, **kwargs)
 
 
 def cswap(
@@ -203,46 +203,46 @@ def ecr(
 
 
 def gphase(
-    angle: GateParameterType,
+    theta: GateParameterType,
     **kwargs,
 ) -> None:
     """Global phase gate.
 
     Args:
-        angle (GateParameterType): Global phase in radians.
+        theta (GateParameterType): Global phase in radians.
 
     """
-    _qubit_instruction("gphase", [], angle, **kwargs)
+    _qubit_instruction("gphase", [], theta, **kwargs)
 
 
 def gpi(
     target: QubitIdentifierType,
-    angle: GateParameterType,
+    theta: GateParameterType,
     **kwargs,
 ) -> None:
     """IonQ GPi gate.
 
     Args:
         target (QubitIdentifierType): Target qubit.
-        angle (GateParameterType): Rotation angle in radians.
+        theta (GateParameterType): Rotation angle in radians.
 
     """
-    _qubit_instruction("gpi", [target], angle, **kwargs)
+    _qubit_instruction("gpi", [target], theta, **kwargs)
 
 
 def gpi2(
     target: QubitIdentifierType,
-    angle: GateParameterType,
+    theta: GateParameterType,
     **kwargs,
 ) -> None:
     """IonQ GPi2 gate.
 
     Args:
         target (QubitIdentifierType): Target qubit.
-        angle (GateParameterType): Rotation angle in radians.
+        theta (GateParameterType): Rotation angle in radians.
 
     """
-    _qubit_instruction("gpi2", [target], angle, **kwargs)
+    _qubit_instruction("gpi2", [target], theta, **kwargs)
 
 
 def h(
@@ -309,17 +309,17 @@ def ms(
 
 def phaseshift(
     target: QubitIdentifierType,
-    angle: GateParameterType,
+    theta: GateParameterType,
     **kwargs,
 ) -> None:
     """Phase shift gate.
 
     Args:
         target (QubitIdentifierType): Target qubit.
-        angle (GateParameterType): Rotation angle in radians.
+        theta (GateParameterType): Rotation angle in radians.
 
     """
-    _qubit_instruction("phaseshift", [target], angle, **kwargs)
+    _qubit_instruction("phaseshift", [target], theta, **kwargs)
 
 
 def prx(
@@ -342,7 +342,7 @@ def prx(
 def pswap(
     target_0: QubitIdentifierType,
     target_1: QubitIdentifierType,
-    angle: GateParameterType,
+    theta: GateParameterType,
     **kwargs,
 ) -> None:
     """PSwap gate.
@@ -350,55 +350,55 @@ def pswap(
     Args:
         target_0 (QubitIdentifierType): Target qubit 0.
         target_1 (QubitIdentifierType): Target qubit 1.
-        angle (GateParameterType): Rotation angle in radians.
+        theta (GateParameterType): Rotation angle in radians.
 
     """
-    _qubit_instruction("pswap", [target_0, target_1], angle, **kwargs)
+    _qubit_instruction("pswap", [target_0, target_1], theta, **kwargs)
 
 
 def rx(
     target: QubitIdentifierType,
-    angle: GateParameterType,
+    theta: GateParameterType,
     **kwargs,
 ) -> None:
     """X-axis rotation gate.
 
     Args:
         target (QubitIdentifierType): Target qubit.
-        angle (GateParameterType): Rotation angle in radians.
+        theta (GateParameterType): Rotation angle in radians.
 
     """
-    _qubit_instruction("rx", [target], angle, **kwargs)
+    _qubit_instruction("rx", [target], theta, **kwargs)
 
 
 def ry(
     target: QubitIdentifierType,
-    angle: GateParameterType,
+    theta: GateParameterType,
     **kwargs,
 ) -> None:
     """Y-axis rotation gate.
 
     Args:
         target (QubitIdentifierType): Target qubit.
-        angle (GateParameterType): Rotation angle in radians.
+        theta (GateParameterType): Rotation angle in radians.
 
     """
-    _qubit_instruction("ry", [target], angle, **kwargs)
+    _qubit_instruction("ry", [target], theta, **kwargs)
 
 
 def rz(
     target: QubitIdentifierType,
-    angle: GateParameterType,
+    theta: GateParameterType,
     **kwargs,
 ) -> None:
     """Z-axis rotation gate.
 
     Args:
         target (QubitIdentifierType): Target qubit.
-        angle (GateParameterType): Rotation angle in radians.
+        theta (GateParameterType): Rotation angle in radians.
 
     """
-    _qubit_instruction("rz", [target], angle, **kwargs)
+    _qubit_instruction("rz", [target], theta, **kwargs)
 
 
 def s(
@@ -529,7 +529,7 @@ def x(
 def xx(
     target_0: QubitIdentifierType,
     target_1: QubitIdentifierType,
-    angle: GateParameterType,
+    theta: GateParameterType,
     **kwargs,
 ) -> None:
     """Ising XX coupling gate.
@@ -537,16 +537,16 @@ def xx(
     Args:
         target_0 (QubitIdentifierType): Target qubit 0.
         target_1 (QubitIdentifierType): Target qubit 1.
-        angle (GateParameterType): Rotation angle in radians.
+        theta (GateParameterType): Rotation angle in radians.
 
     """
-    _qubit_instruction("xx", [target_0, target_1], angle, **kwargs)
+    _qubit_instruction("xx", [target_0, target_1], theta, **kwargs)
 
 
 def xy(
     target_0: QubitIdentifierType,
     target_1: QubitIdentifierType,
-    angle: GateParameterType,
+    theta: GateParameterType,
     **kwargs,
 ) -> None:
     """XY gates
@@ -554,10 +554,10 @@ def xy(
     Args:
         target_0 (QubitIdentifierType): Target qubit 0.
         target_1 (QubitIdentifierType): Target qubit 1.
-        angle (GateParameterType): Rotation angle in radians.
+        theta (GateParameterType): Rotation angle in radians.
 
     """
-    _qubit_instruction("xy", [target_0, target_1], angle, **kwargs)
+    _qubit_instruction("xy", [target_0, target_1], theta, **kwargs)
 
 
 def y(
@@ -576,7 +576,7 @@ def y(
 def yy(
     target_0: QubitIdentifierType,
     target_1: QubitIdentifierType,
-    angle: GateParameterType,
+    theta: GateParameterType,
     **kwargs,
 ) -> None:
     """Ising YY coupling gate.
@@ -584,10 +584,10 @@ def yy(
     Args:
         target_0 (QubitIdentifierType): Target qubit 0.
         target_1 (QubitIdentifierType): Target qubit 1.
-        angle (GateParameterType): Rotation angle in radians.
+        theta (GateParameterType): Rotation angle in radians.
 
     """
-    _qubit_instruction("yy", [target_0, target_1], angle, **kwargs)
+    _qubit_instruction("yy", [target_0, target_1], theta, **kwargs)
 
 
 def z(
@@ -606,7 +606,7 @@ def z(
 def zz(
     target_0: QubitIdentifierType,
     target_1: QubitIdentifierType,
-    angle: GateParameterType,
+    theta: GateParameterType,
     **kwargs,
 ) -> None:
     """Ising ZZ coupling gate.
@@ -614,7 +614,7 @@ def zz(
     Args:
         target_0 (QubitIdentifierType): Target qubit 0.
         target_1 (QubitIdentifierType): Target qubit 1.
-        angle (GateParameterType): Rotation angle in radians.
+        theta (GateParameterType): Rotation angle in radians.
 
     """
-    _qubit_instruction("zz", [target_0, target_1], angle, **kwargs)
+    _qubit_instruction("zz", [target_0, target_1], theta, **kwargs)

--- a/test/unit_tests/autoqasm/test_api.py
+++ b/test/unit_tests/autoqasm/test_api.py
@@ -1094,17 +1094,17 @@ def test_input_types():
     @aq.main
     def multiple_input_types(x: int, y: bool, z: float, u):
         if x and y:
-            rx(target=0, angle=u + z)
+            rx(target=0, theta=u + z)
 
     @aq.main()
     def multiple_input_types_parens(x: int, y: bool, z: float, u):
         if x and y:
-            rx(target=0, angle=u + z)
+            rx(target=0, theta=u + z)
 
     @aq.main(num_qubits=1)
     def multiple_input_types_params(x: int, y: bool, z: float, u):
         if x and y:
-            rx(target=0, angle=u + z)
+            rx(target=0, theta=u + z)
 
     expected_ir = """OPENQASM 3.0;
 input int[32] x;

--- a/test/unit_tests/autoqasm/test_devices.py
+++ b/test/unit_tests/autoqasm/test_devices.py
@@ -279,7 +279,7 @@ def test_aws_device_run(
     @aq.main
     def my_program():
         h(0)
-        rx(0, FreeParameter("angle"))
+        rx(0, FreeParameter("theta"))
 
     aws_device = AwsDevice(Devices.Amazon.SV1.value)
     _ = aws_device.run(my_program, shots=10, inputs=inputs, device_parameters=device_parameters)

--- a/test/unit_tests/autoqasm/test_gate_calibrations.py
+++ b/test/unit_tests/autoqasm/test_gate_calibrations.py
@@ -29,7 +29,7 @@ def test_gate_calibrations_fixed_args():
     def cal_1():
         pulse.barrier("$0")
 
-    @aq.gate_calibration(implements=rx, target="$1", angle=1.789)
+    @aq.gate_calibration(implements=rx, target="$1", theta=1.789)
     def cal_2():
         pulse.delay("$1", 0.123)
 
@@ -59,8 +59,8 @@ def test_gate_calibrations_variable_args():
     """test gate calibrations with variable args"""
 
     @aq.gate_calibration(implements=rx, target="$1")
-    def cal_1(angle: float):
-        pulse.delay("$1", angle)
+    def cal_1(theta: float):
+        pulse.delay("$1", theta)
 
     @aq.main
     def my_program():
@@ -69,8 +69,8 @@ def test_gate_calibrations_variable_args():
     expected = textwrap.dedent(
         """
         OPENQASM 3.0;
-        defcal rx(angle[32] angle) $1 {
-            delay[angle * 1s] $1;
+        defcal rx(angle[32] theta) $1 {
+            delay[theta * 1s] $1;
         }
         rx(1.0) $1;
         """
@@ -83,8 +83,8 @@ def test_gate_calibrations_invalid_args():
     """test gate calibrations with invalid args name"""
 
     @aq.gate_calibration(implements=rx, target="$1", foo=0)
-    def cal_1(angle: float):
-        pulse.delay("$1", angle)
+    def cal_1(theta: float):
+        pulse.delay("$1", theta)
 
     @aq.main
     def my_program():
@@ -98,24 +98,24 @@ def test_gate_calibrations_invalid_type():
     """test gate calibrations with invalid args type"""
 
     @aq.gate_calibration(implements=rx, target=0.123)
-    def cal_1(angle: float):
-        pulse.delay("$1", angle)
+    def cal_1(theta: float):
+        pulse.delay("$1", theta)
 
     @aq.gate_calibration(implements=rx, target={"foo": "bar"})
-    def cal_2(angle: float):
-        pulse.delay("$1", angle)
+    def cal_2(theta: float):
+        pulse.delay("$1", theta)
 
-    @aq.gate_calibration(implements=rx, target=0, angle="$0")
+    @aq.gate_calibration(implements=rx, target=0, theta="$0")
     def cal_3():
         pulse.delay("$1", 0.123)
 
     @aq.gate_calibration(implements=rx, target=0)
-    def cal_4(angle: aq.Qubit):
-        pulse.delay("$1", angle)
+    def cal_4(theta: aq.Qubit):
+        pulse.delay("$1", theta)
 
     @aq.gate_calibration(implements=rx)
-    def cal_5(target: float, angle: aq.Qubit):
-        pulse.delay("$0", angle)
+    def cal_5(target: float, theta: aq.Qubit):
+        pulse.delay("$0", theta)
 
     @aq.main
     def my_program():
@@ -134,8 +134,8 @@ def test_gate_calibrations_insufficient_args():
         pulse.delay("$1", 0.123)
 
     @aq.gate_calibration(implements=rx)
-    def cal_2(angle: float):
-        pulse.delay("$1", angle)
+    def cal_2(theta: float):
+        pulse.delay("$1", theta)
 
     @aq.main
     def my_program():
@@ -151,9 +151,9 @@ def test_gate_calibrations_insufficient_args():
 def test_gate_calibrations_duplicated_args():
     """test gate calibrations with duplicated args"""
 
-    @aq.gate_calibration(implements=rx, target="$1", angle=0.123)
-    def cal_1(angle: float):
-        pulse.delay("$1", angle)
+    @aq.gate_calibration(implements=rx, target="$1", theta=0.123)
+    def cal_1(theta: float):
+        pulse.delay("$1", theta)
 
     @aq.main
     def my_program():
@@ -167,9 +167,9 @@ def test_gate_calibrations_invalid_instructions():
     """test gate calibrations with invalid instructions that are not pulse"""
 
     @aq.gate_calibration(implements=rx, target="$1")
-    def cal_1(angle: float):
+    def cal_1(theta: float):
         h(0)
-        pulse.delay("$1", angle)
+        pulse.delay("$1", theta)
 
     @aq.main
     def my_program():
@@ -183,8 +183,8 @@ def test_gate_calibrations_bind_calibrations_not_inplace():
     """test that bind_calibrations does not modify the original program"""
 
     @aq.gate_calibration(implements=rx, target="$1")
-    def cal_1(angle: float):
-        pulse.delay("$1", angle)
+    def cal_1(theta: float):
+        pulse.delay("$1", theta)
 
     @aq.main
     def my_program():

--- a/test/unit_tests/autoqasm/test_parameters.py
+++ b/test/unit_tests/autoqasm/test_parameters.py
@@ -322,19 +322,19 @@ def test_parametric_pulse_cals():
     """Test that pulse calibrations work with free parameters."""
 
     @aq.gate_calibration(implements=rx, target="$1")
-    def cal_1(angle: float):
-        pulse.delay("$1", angle)
+    def cal_1(theta: float):
+        pulse.delay("$1", theta)
 
     @aq.main
-    def my_program(theta):
-        rx("$1", theta)
+    def my_program(a):
+        rx("$1", a)
 
     expected = """OPENQASM 3.0;
-input float theta;
-defcal rx(angle[32] angle) $1 {
-    delay[angle * 1s] $1;
+input float a;
+defcal rx(angle[32] theta) $1 {
+    delay[theta * 1s] $1;
 }
-rx(theta) $1;"""
+rx(a) $1;"""
     qasm = my_program.build().with_calibrations(cal_1).to_ir()
     assert qasm == expected
 
@@ -442,23 +442,23 @@ def test_binding_pulse_parameters():
     """Test binding programs with parametric pulse instructions."""
 
     @aq.gate_calibration(implements=rx, target="$1")
-    def cal_1(angle: float):
-        pulse.delay("$1", angle)
+    def cal_1(theta: float):
+        pulse.delay("$1", theta)
 
     @aq.main
-    def my_program(theta):
-        rx("$1", theta)
+    def my_program(a):
+        rx("$1", a)
 
-    qasm1 = my_program.build().with_calibrations(cal_1).make_bound_program({"theta": 0.6}).to_ir()
-    qasm2 = my_program.build().make_bound_program({"theta": 0.6}).with_calibrations(cal_1).to_ir()
+    qasm1 = my_program.build().with_calibrations(cal_1).make_bound_program({"a": 0.6}).to_ir()
+    qasm2 = my_program.build().make_bound_program({"a": 0.6}).with_calibrations(cal_1).to_ir()
     assert qasm1 == qasm2
 
     expected = """OPENQASM 3.0;
-float theta = 0.6;
-defcal rx(angle[32] angle) $1 {
-    delay[angle * 1s] $1;
+float a = 0.6;
+defcal rx(angle[32] theta) $1 {
+    delay[theta * 1s] $1;
 }
-rx(theta) $1;"""
+rx(a) $1;"""
     assert expected == qasm1
 
 

--- a/test/unit_tests/autoqasm/test_pulse.py
+++ b/test/unit_tests/autoqasm/test_pulse.py
@@ -188,17 +188,17 @@ def test_pulse_freeparameter() -> None:
     """Test pulse program with free parameter."""
 
     @aq.main
-    def my_program(duration):
-        delay(["$3", "$4"], duration)
+    def my_program(duration1):
+        delay(["$3", "$4"], duration1)
         delay(["$3", "$4"], FreeParameter("duration2"))
 
     expected = textwrap.dedent(
         """
         OPENQASM 3.0;
-        input float duration;
+        input float duration1;
         input float duration2;
         cal {
-            delay[duration * 1s] $3, $4;
+            delay[duration1 * 1s] $3, $4;
             delay[duration2 * 1s] $3, $4;
         }
         """
@@ -210,19 +210,19 @@ def test_pulse_freeparameter_bound() -> None:
     """Test pulse program with freeparameter bound with values."""
 
     @aq.main
-    def my_program(duration):
-        delay(["$3", "$4"], duration)
+    def my_program(duration1):
+        delay(["$3", "$4"], duration1)
 
     expected = textwrap.dedent(
         """
         OPENQASM 3.0;
-        float duration = 0.123;
+        float duration1 = 0.123;
         cal {
-            delay[duration * 1s] $3, $4;
+            delay[duration1 * 1s] $3, $4;
         }
         """
     ).strip()
-    qasm = my_program.build().make_bound_program({"duration": 0.123}).to_ir()
+    qasm = my_program.build().make_bound_program({"duration1": 0.123}).to_ir()
     assert qasm == expected
 
 
@@ -230,21 +230,21 @@ def test_pulse_freeparameter_condition() -> None:
     """Test pulse program with freeparameter in condition."""
 
     @aq.main
-    def my_program(duration, duration2):
-        delay(["$3", "$4"], duration)
-        if duration > duration2:
+    def my_program(duration1, duration2):
+        delay(["$3", "$4"], duration1)
+        if duration1 > duration2:
             delay(["$3", "$4"], duration2)
 
     expected = textwrap.dedent(
         """
         OPENQASM 3.0;
-        input float duration;
+        input float duration1;
         input float duration2;
         cal {
-            delay[duration * 1s] $3, $4;
+            delay[duration1 * 1s] $3, $4;
         }
         bool __bool_0__;
-        __bool_0__ = duration > duration2;
+        __bool_0__ = duration1 > duration2;
         if (__bool_0__) {
             cal {
                 delay[duration2 * 1s] $3, $4;


### PR DESCRIPTION
*Issue #, if available:*
Resolves #34 

*Description of changes:*
Ensure that all tests generate valid OpenQASM, mostly by removing usage of the reserved keyword `angle` and `duration` as parameter names. This unblocks upgrading to the latest released version of the Braket SDK, so this PR does that as well.

*Testing done:*
All unit tests pass. `tox -e notebooks` passes.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/autoqasm/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/autoqasm/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/autoqasm/blob/main/README.md) and [API docs](https://github.com/amazon-braket/autoqasm/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
