### PR TITLE
fix: raise when a free parameter is registered with a conflicting type

### DIFF
--- a/src/autoqasm/program/program.py
+++ b/src/autoqasm/program/program.py
@@ -483,23 +483,36 @@ class ProgramConversionContext:
 
         Raises:
             NotImplementedError: If the parameter type is not supported.
+            errors.ParameterTypeError: If ``name`` is already registered with
+                a different type.
         """
-        # TODO (#814): add type validation against existing inputs
-        if name not in self._input_parameters:
-            aq_type = aq_types.map_parameter_type(param_type)
-            if aq_type not in [oqpy.FloatVar, oqpy.IntVar, oqpy.BoolVar]:
-                raise NotImplementedError(param_type)
+        if name in self._input_parameters:
+            existing = self._input_parameters[name]
+            expected_type = aq_types.map_parameter_type(param_type)
+            if type(existing) is not expected_type:
+                raise errors.ParameterTypeError(
+                    f'Input parameter "{name}" was already registered as '
+                    f"{type(existing).__name__}, but a later use implies "
+                    f"{expected_type.__name__}. Make the types match, for "
+                    "example by updating the @aq.main signature to match "
+                    "the type expected by the gate or subroutine that "
+                    "consumes the parameter."
+                )
+            return
+        aq_type = aq_types.map_parameter_type(param_type)
+        if aq_type not in [oqpy.FloatVar, oqpy.IntVar, oqpy.BoolVar]:
+            raise NotImplementedError(param_type)
 
-            # In case a FreeParameter has already created a FloatVar somewhere else,
-            # we use need_declaration=False to avoid OQPy raising name conflict errors.
-            if aq_type == oqpy.FloatVar:
-                var = aq_type("input", name=name, needs_declaration=False)
-                var.size = None
-                var.type.size = None
-            else:
-                var = aq_type("input", name=name)
-            self._input_parameters[name] = var
-            return var
+        # In case a FreeParameter has already created a FloatVar somewhere else,
+        # we use need_declaration=False to avoid OQPy raising name conflict errors.
+        if aq_type == oqpy.FloatVar:
+            var = aq_type("input", name=name, needs_declaration=False)
+            var.size = None
+            var.type.size = None
+        else:
+            var = aq_type("input", name=name)
+        self._input_parameters[name] = var
+        return var
 
     def register_output_parameter(
         self, name: str, value: bool | float | oqpy.base.Var | oqpy.OQPyExpression | None

--- a/test/unit_tests/autoqasm/test_parameter_type_collision.py
+++ b/test/unit_tests/autoqasm/test_parameter_type_collision.py
@@ -1,0 +1,84 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+"""Tests for type-collision detection on input-parameter registration."""
+
+import pytest
+from braket.circuits.free_parameter import FreeParameter
+
+import autoqasm as aq
+from autoqasm.instructions import rx
+
+
+def test_signature_int_conflicts_with_free_parameter_float() -> None:
+    """A signature annotation of ``int`` conflicts with the implicit
+    ``float`` type produced by passing ``FreeParameter(...)`` to a gate
+    angle. We must raise rather than silently coerce one type to the other.
+    """
+
+    @aq.main
+    def collision(theta: int):
+        rx(0, FreeParameter("theta"))
+
+    with pytest.raises(aq.errors.ParameterTypeError, match="theta"):
+        collision.build()
+
+
+def test_signature_bool_conflicts_with_free_parameter_float() -> None:
+    @aq.main
+    def collision(theta: bool):
+        rx(0, FreeParameter("theta"))
+
+    with pytest.raises(aq.errors.ParameterTypeError, match="theta"):
+        collision.build()
+
+
+def test_matching_types_are_ok() -> None:
+    """Matching types (float + float) must not raise."""
+
+    @aq.main
+    def ok(theta: float):
+        rx(0, FreeParameter("theta"))
+
+    ir = ok.build().to_ir()
+    assert "input float theta;" in ir
+
+
+def test_bare_free_parameter_is_fine() -> None:
+    """Without a conflicting signature annotation, ``FreeParameter`` keeps
+    working as it always has."""
+
+    @aq.main
+    def ok():
+        rx(0, FreeParameter("theta"))
+
+    ir = ok.build().to_ir()
+    assert "input float theta;" in ir
+
+
+def test_register_input_parameter_same_type_is_idempotent() -> None:
+    """Registering the same parameter twice with the same type is a no-op."""
+    with aq.build_program() as ctx:
+        first = ctx.register_input_parameter("theta", float)
+        result = ctx.register_input_parameter("theta", float)
+        # The second call returns None (already registered) and the
+        # underlying var object is unchanged.
+        assert result is None
+        assert ctx._input_parameters["theta"] is first
+
+
+def test_register_input_parameter_conflicting_types_raises() -> None:
+    with aq.build_program() as ctx:
+        ctx.register_input_parameter("theta", int)
+        with pytest.raises(aq.errors.ParameterTypeError, match="theta"):
+            ctx.register_input_parameter("theta", float)


### PR DESCRIPTION
*Issue #, if available:*
resolves #14 

*Description of changes:*

Catches the case where the same free-parameter name is registered twice with different types (e.g. once as float and once as int) and raises a clear error at registration time instead of silently overwriting. Prevents a class of subtle correctness bugs where later uses of the parameter would have silently taken on the most recently registered type.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/autoqasm/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/autoqasm/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/autoqasm/blob/main/README.md) and [API docs](https://github.com/amazon-braket/autoqasm/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
