### PR TITLE
fix: accept positional-only parameters on autoqasm subroutines

### DIFF
--- a/src/autoqasm/api.py
+++ b/src/autoqasm/api.py
@@ -465,9 +465,17 @@ def _wrap_for_oqpy_subroutine(f: Callable, options: converter.ConversionOptions)
             all_param_names.add(new_name)
         _func.__annotations__.pop(param.name)
 
+        # OpenQASM subroutines have no concept of positional-only arguments,
+        # so promote any positional-only user parameter to positional-or-keyword.
+        new_kind = (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD
+            if param.kind == inspect.Parameter.POSITIONAL_ONLY
+            else param.kind
+        )
+
         new_param = inspect.Parameter(
             name=new_name,
-            kind=param.kind,
+            kind=new_kind,
             annotation=aq_types.map_parameter_type(param.annotation),
         )
         new_params.append(new_param)

--- a/test/unit_tests/autoqasm/test_positional_only.py
+++ b/test/unit_tests/autoqasm/test_positional_only.py
@@ -1,0 +1,62 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+"""Tests that positional-only subroutine parameters work."""
+
+import autoqasm as aq
+from autoqasm.instructions import rx
+
+
+def test_positional_only_subroutine_parameter_builds() -> None:
+    @aq.subroutine
+    def my_sub(a: float, /, b: float):
+        rx(0, a + b)
+
+    @aq.main(num_qubits=1)
+    def prog():
+        my_sub(0.1, 0.2)
+
+    ir = prog.build().to_ir()
+    assert "def my_sub(float[64] a, float[64] b)" in ir
+    assert "my_sub(0.1, 0.2);" in ir
+
+
+def test_mixed_positional_only_and_positional_or_keyword_builds() -> None:
+    """Multiple positional-only arguments followed by regular ones."""
+
+    @aq.subroutine
+    def my_sub(a: float, b: float, /, c: float, d: float):
+        rx(0, a + b + c + d)
+
+    @aq.main(num_qubits=1)
+    def prog():
+        my_sub(0.1, 0.2, 0.3, 0.4)
+
+    ir = prog.build().to_ir()
+    assert "def my_sub(float[64] a, float[64] b, float[64] c, float[64] d)" in ir
+
+
+def test_positional_only_subroutine_with_qubit_argument() -> None:
+    """The common case: a subroutine that takes a qubit argument before
+    the positional-only barrier."""
+
+    @aq.subroutine
+    def my_sub(q: aq.Qubit, /, theta: float):
+        rx(q, theta)
+
+    @aq.main(num_qubits=1)
+    def prog():
+        my_sub(0, 0.5)
+
+    ir = prog.build().to_ir()
+    assert "def my_sub(qubit q, float[64] theta)" in ir


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Allows the `@aq.subroutine` decorator to handle Python positional-only parameters (arguments declared before a `/` in the signature) instead of rejecting them during signature inspection. Brings AutoQASM subroutine signatures to better parity with standard Python function syntax.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/autoqasm/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/autoqasm/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/autoqasm/blob/main/README.md) and [API docs](https://github.com/amazon-braket/autoqasm/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
