### PR TITLE
change: refactor qubit types into new submodule

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -4,6 +4,8 @@ import datetime
 from importlib.metadata import version
 
 from pygments.formatters import LatexFormatter
+from pygments.lexers import PythonLexer
+from sphinx.highlighting import lexers
 
 # Sphinx configuration below.
 project = "autoqasm"
@@ -23,6 +25,10 @@ extensions = [
 ]
 
 nbsphinx_execute = "never"
+
+# The notebooks declare the `ipython3` lexer, an alias provided by IPython rather than
+# Pygments. Map it to the standard Python lexer so highlighting resolves without IPython.
+lexers["ipython3"] = PythonLexer()
 
 exclude_patterns = ["**/.ipynb_checkpoints"]
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,8 +26,6 @@ extensions = [
 
 nbsphinx_execute = "never"
 
-# The notebooks declare the `ipython3` lexer, an alias provided by IPython rather than
-# Pygments. Map it to the standard Python lexer so highlighting resolves without IPython.
 lexers["ipython3"] = PythonLexer()
 
 exclude_patterns = ["**/.ipynb_checkpoints"]

--- a/src/autoqasm/__init__.py
+++ b/src/autoqasm/__init__.py
@@ -50,6 +50,7 @@ from ._version import __version__  # noqa: F401
 from .api import gate, gate_calibration, main, subroutine  # noqa: F401
 from .instructions import QubitIdentifierType as Qubit  # noqa: F401
 from .program import Program, build_program, verbatim  # noqa: F401
+from .program import get_program_conversion_context as _get_program_conversion_context
 from .transpiler import transpiler  # noqa: F401
 from .types import ArrayVar, BitVar, BoolVar, FloatVar, IntVar  # noqa: F401
 from .types import Range as range  # noqa: F401
@@ -57,5 +58,5 @@ from .types import Range as range  # noqa: F401
 
 def __getattr__(name):
     if name == "qubits":
-        return instructions.global_qubit_register()
+        return _get_program_conversion_context().global_qubit_register
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/autoqasm/converters/arithmetic.py
+++ b/src/autoqasm/converters/arithmetic.py
@@ -28,10 +28,12 @@ class ArithmeticTransformer(converter.Base):
 
     def visit_BinOp(self, node: ast.stmt) -> ast.stmt:
         """Transforms a BinOp node.
-        Args :
-            node(ast.stmt) : AST node to transform
-        Returns :
-            ast.stmt : Transformed node
+
+        Args:
+            node (ast.stmt): AST node to transform
+
+        Returns:
+            ast.stmt: Transformed node
         """
         node = self.generic_visit(node)
         op_type = type(node.op)
@@ -50,11 +52,13 @@ class ArithmeticTransformer(converter.Base):
 
 def transform(node: ast.stmt, ctx: ag_ctx.ControlStatusCtx) -> ast.stmt:
     """Transform arithmetic nodes.
+
     Args:
-        node(ast.stmt) : AST node to transform
-        ctx (ag_ctx.ControlStatusCtx) : Transformer context.
-    Returns :
-        ast.stmt : Transformed node.
+        node (ast.stmt): AST node to transform
+        ctx (ag_ctx.ControlStatusCtx): Transformer context.
+
+    Returns:
+        ast.stmt: Transformed node.
     """
 
     return ArithmeticTransformer(ctx).visit(node)

--- a/src/autoqasm/errors.py
+++ b/src/autoqasm/errors.py
@@ -15,6 +15,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 
 class AutoQasmError(Exception):
     """Base class for all AutoQASM exceptions."""
@@ -52,6 +54,20 @@ class InvalidTargetQubit(AutoQasmError):
     """Target qubit is invalid in the current context."""
 
 
+class InvalidQubitIdentifier(AutoQasmError):
+    """An object cannot be used as a qubit identifier."""
+
+    def __init__(self, qid: Any):
+        """
+        Args:
+            qid (Any): The object that was supplied where a single qubit was expected.
+        """
+        super().__init__(
+            f'Invalid qubit identifier: "{qid}". Must be a single qubit, '
+            f"not an object of type '{type(qid).__name__}'."
+        )
+
+
 class UnsupportedGate(AutoQasmError):
     """Gate is not supported by the target device."""
 
@@ -68,7 +84,7 @@ class UnknownQubitCountError(AutoQasmError):
     """Missing declaration for the number of qubits."""
 
     def __init__(self):
-        self.message = """Unspecified number of qubits.
+        super().__init__("""Unspecified number of qubits.
 
 Specify the number of qubits used by your program by supplying the \
 `num_qubits` argument to `aq.main`. For example:
@@ -76,10 +92,7 @@ Specify the number of qubits used by your program by supplying the \
     @aq.main(num_qubits=5)
     def my_autoqasm_program():
         ...
-"""
-
-    def __str__(self):
-        return self.message
+""")
 
 
 class OutsideProgramContextError(AutoQasmError):
@@ -96,7 +109,7 @@ class OutsideProgramContextError(AutoQasmError):
                 slightly more pointed error message.
         """
         feature_description = f"`{feature}`" if feature else "This AutoQASM feature"
-        self.message = f"""{feature_description} can only be used inside a function decorated \
+        super().__init__(f"""{feature_description} can only be used inside a function decorated \
 with `@aq.main`, `@aq.subroutine`, `@aq.gate`, or `@aq.gate_calibration`.
 
 For example:
@@ -112,10 +125,7 @@ For example:
 
 If you want to build a program programmatically, use the `aq.build_program()` \
 context manager directly.
-"""
-
-    def __str__(self):
-        return self.message
+""")
 
 
 class BuildError(AutoQasmError):
@@ -136,13 +146,10 @@ class UnsupportedConditionalExpressionError(AutoQasmError):
     def __init__(self, true_type: type | None, false_type: type | None):
         if_type = true_type.__name__ if true_type else "None"
         else_type = false_type.__name__ if false_type else "None"
-        self.message = f"""\
+        super().__init__(f"""\
 `if` clause resolves to {if_type}, but `else` clause resolves to {else_type}. \
 Both the `if` and `else` clauses of an inline conditional expression \
-must resolve to the same type."""
-
-    def __str__(self):
-        return self.message
+must resolve to the same type.""")
 
 
 class InvalidAssignmentStatement(AutoQasmError):

--- a/src/autoqasm/instructions/__init__.py
+++ b/src/autoqasm/instructions/__init__.py
@@ -28,4 +28,3 @@ Example of using a `h` gate and a `cnot` gate to create a Bell circuit:
 from .gates import *
 from .instructions import barrier, reset  # noqa: F401
 from .measurements import measure, measure_ff  # noqa: F401
-from .qubits import global_qubit_register  # noqa: F401

--- a/src/autoqasm/instructions/instructions.py
+++ b/src/autoqasm/instructions/instructions.py
@@ -23,8 +23,9 @@ import oqpy
 
 from autoqasm import program as aq_program
 from autoqasm import types as aq_types
-from autoqasm.instructions.qubits import _as_qubit_iterable, _qubit
+from autoqasm.instructions.qubits import _qubit
 from autoqasm.types import QubitIdentifierType
+from autoqasm.types.qubits import _as_qubit_iterable
 from braket.circuits.basis_state import BasisState, BasisStateInput
 
 

--- a/src/autoqasm/instructions/measurements.py
+++ b/src/autoqasm/instructions/measurements.py
@@ -29,7 +29,8 @@ from collections.abc import Iterable
 from autoqasm import program
 from autoqasm import types as aq_types
 from autoqasm.instructions.instructions import _qubit_instruction
-from autoqasm.instructions.qubits import _as_qubit_iterable, _qubit
+from autoqasm.instructions.qubits import _qubit
+from autoqasm.types.qubits import _as_qubit_iterable
 
 
 def measure(

--- a/src/autoqasm/instructions/measurements.py
+++ b/src/autoqasm/instructions/measurements.py
@@ -29,7 +29,7 @@ from collections.abc import Iterable
 from autoqasm import program
 from autoqasm import types as aq_types
 from autoqasm.instructions.instructions import _qubit_instruction
-from autoqasm.instructions.qubits import _as_qubit_iterable, _qubit, global_qubit_register
+from autoqasm.instructions.qubits import _as_qubit_iterable, _qubit
 
 
 def measure(
@@ -45,9 +45,10 @@ def measure(
     Returns:
         BitVar: Bit variable the measurement results are assigned to.
     """
-    qubits = _as_qubit_iterable(qubits, default=global_qubit_register())
+    ctx = program.get_program_conversion_context()
+    qubits = _as_qubit_iterable(qubits, default=ctx.global_qubit_register)
 
-    oqpy_program = program.get_program_conversion_context().get_oqpy_program()
+    oqpy_program = ctx.get_oqpy_program()
 
     bit_var_size = len(qubits) if len(qubits) > 1 else None
     bit_var = aq_types.BitVar(

--- a/src/autoqasm/instructions/qubits.py
+++ b/src/autoqasm/instructions/qubits.py
@@ -17,7 +17,6 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Iterable
 from functools import singledispatch
 from typing import Any
 
@@ -25,7 +24,6 @@ import oqpy.base
 from openpulse.printer import dumps
 
 from autoqasm import errors, program
-from autoqasm import types as aq_types
 
 
 def _get_physical_qubit_indices(qids: list[str]) -> list[int]:
@@ -46,20 +44,6 @@ def _get_physical_qubit_indices(qids: list[str]) -> list[int]:
             )
         braket_qubits.append(int(qid[1:]))
     return braket_qubits
-
-
-def _as_qubit_iterable(
-    qubits: aq_types.QubitIdentifierType | Iterable[aq_types.QubitIdentifierType] | None,
-    default: Iterable[aq_types.QubitIdentifierType] | None = None,
-) -> Iterable[aq_types.QubitIdentifierType]:
-    """Normalize a qubit argument to an iterable. ``None`` maps to ``default`` (an empty
-    list if not provided); a single qubit identifier is wrapped in a list; iterables
-    (including :class:`GlobalQubitRegister`) pass through unchanged."""
-    if qubits is None:
-        qubits = default if default is not None else []
-    if aq_types.is_qubit_identifier_type(qubits):
-        return [qubits]
-    return qubits
 
 
 @singledispatch

--- a/src/autoqasm/instructions/qubits.py
+++ b/src/autoqasm/instructions/qubits.py
@@ -17,14 +17,14 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable
 from functools import singledispatch
 from typing import Any
 
 import oqpy.base
 from openpulse.printer import dumps
 
-from autoqasm import constants, errors, program
+from autoqasm import errors, program
 from autoqasm import types as aq_types
 
 
@@ -48,25 +48,6 @@ def _get_physical_qubit_indices(qids: list[str]) -> list[int]:
     return braket_qubits
 
 
-def _global_qubit_register(qubit_idx_expr: int | str) -> oqpy.Qubit:
-    return oqpy.Qubit(f"{constants.QUBIT_REGISTER}[{qubit_idx_expr}]", needs_declaration=False)
-
-
-class GlobalQubitRegister(oqpy.Qubit):
-    def __init__(self, size: int | None):
-        super().__init__(name=constants.QUBIT_REGISTER, size=size, needs_declaration=False)
-
-    def __len__(self) -> int:
-        return self.size
-
-    def __iter__(self) -> Iterator:
-        return iter(range(len(self)))
-
-
-def global_qubit_register() -> GlobalQubitRegister:
-    return program.get_program_conversion_context().global_qubit_register
-
-
 def _as_qubit_iterable(
     qubits: aq_types.QubitIdentifierType | Iterable[aq_types.QubitIdentifierType] | None,
     default: Iterable[aq_types.QubitIdentifierType] | None = None,
@@ -76,7 +57,7 @@ def _as_qubit_iterable(
     (including :class:`GlobalQubitRegister`) pass through unchanged."""
     if qubits is None:
         qubits = default if default is not None else []
-    if aq_types.is_qubit_identifier_type(qubits) and not isinstance(qubits, GlobalQubitRegister):
+    if aq_types.is_qubit_identifier_type(qubits):
         return [qubits]
     return qubits
 
@@ -107,32 +88,29 @@ def _(qid: float) -> oqpy.Qubit:
 @_qubit.register
 def _(qid: int) -> oqpy.Qubit:
     # Integer virtual qubit, like `h(0)`
-    program.get_program_conversion_context().register_qubit(qid)
-    return _global_qubit_register(qid)
-
-
-@_qubit.register
-def _(qid: GlobalQubitRegister) -> oqpy.Qubit:
-    raise ValueError("qubit index must be a single value, not a list or a register")
+    ctx = program.get_program_conversion_context()
+    ctx.register_qubit(qid)
+    return ctx.global_qubit_register[qid]
 
 
 @_qubit.register
 def _(qid: oqpy._ClassicalVar) -> oqpy.Qubit:
     # Indexed by variable, such as i in range(n); h(i)
-    if program.get_program_conversion_context().get_declared_qubits() is None:
+    ctx = program.get_program_conversion_context()
+    if ctx.get_declared_qubits() is None:
         raise errors.UnknownQubitCountError()
-    return _global_qubit_register(qid.name)
+    return ctx.global_qubit_register[qid.name]
 
 
 @_qubit.register
 def _(qid: oqpy.base.OQPyExpression) -> oqpy.Qubit:
     # Indexed by expression, such as i in range(n); h(i + 1)
-    if program.get_program_conversion_context().get_declared_qubits() is None:
+    ctx = program.get_program_conversion_context()
+    if ctx.get_declared_qubits() is None:
         raise errors.UnknownQubitCountError()
 
-    oqpy_program = program.get_program_conversion_context().get_oqpy_program()
-    qubit_idx_expr = dumps(qid.to_ast(oqpy_program))
-    return _global_qubit_register(qubit_idx_expr)
+    qubit_idx_expr = dumps(qid.to_ast(ctx.get_oqpy_program()))
+    return ctx.global_qubit_register[qubit_idx_expr]
 
 
 @_qubit.register

--- a/src/autoqasm/instructions/qubits.py
+++ b/src/autoqasm/instructions/qubits.py
@@ -56,12 +56,12 @@ def _qubit(qid: Any) -> oqpy.Qubit:
     Returns:
         Qubit: A translated oqpy qubit.
     """
-    raise ValueError(f"invalid qubit label: '{qid}'")
+    raise TypeError(f"object of type '{type(qid).__name__}' cannot be used as a qubit: '{qid}'")
 
 
 @_qubit.register
 def _(qid: bool) -> oqpy.Qubit:
-    raise ValueError(f"invalid qubit label: '{qid}'")
+    raise TypeError(f"qubit index cannot be a bool: '{qid}'")
 
 
 @_qubit.register

--- a/src/autoqasm/instructions/qubits.py
+++ b/src/autoqasm/instructions/qubits.py
@@ -55,15 +55,18 @@ def _qubit(qid: Any) -> oqpy.Qubit:
 
     Returns:
         Qubit: A translated oqpy qubit.
+
+    Raises:
+        errors.InvalidQubitIdentifier: ``qid`` cannot be used as a qubit.
     """
-    raise TypeError(f"object of type '{type(qid).__name__}' cannot be used as a qubit")
+    raise errors.InvalidQubitIdentifier(qid)
 
 
 @_qubit.register
 def _(qid: bool) -> oqpy.Qubit:
     # `bool` is a subclass of `int`, so without this, `singledispatch` would route
     # `h(True)` to the `int` arm and emit a gate on qubit 1.
-    raise TypeError(f"object of type '{type(qid).__name__}' cannot be used as a qubit")
+    raise errors.InvalidQubitIdentifier(qid)
 
 
 @_qubit.register

--- a/src/autoqasm/instructions/qubits.py
+++ b/src/autoqasm/instructions/qubits.py
@@ -56,17 +56,12 @@ def _qubit(qid: Any) -> oqpy.Qubit:
     Returns:
         Qubit: A translated oqpy qubit.
     """
-    raise TypeError(f"object of type '{type(qid).__name__}' cannot be used as a qubit: '{qid}'")
+    raise TypeError(f"object of type '{type(qid).__name__}' cannot be used as a qubit")
 
 
 @_qubit.register
 def _(qid: bool) -> oqpy.Qubit:
-    raise TypeError(f"qubit index cannot be a bool: '{qid}'")
-
-
-@_qubit.register
-def _(qid: float) -> oqpy.Qubit:
-    raise TypeError(f"qubit index cannot be a float: '{qid}'")
+    raise TypeError(f"object of type '{type(qid).__name__}' cannot be used as a qubit")
 
 
 @_qubit.register

--- a/src/autoqasm/instructions/qubits.py
+++ b/src/autoqasm/instructions/qubits.py
@@ -61,6 +61,8 @@ def _qubit(qid: Any) -> oqpy.Qubit:
 
 @_qubit.register
 def _(qid: bool) -> oqpy.Qubit:
+    # `bool` is a subclass of `int`, so without this, `singledispatch` would route
+    # `h(True)` to the `int` arm and emit a gate on qubit 1.
     raise TypeError(f"object of type '{type(qid).__name__}' cannot be used as a qubit")
 
 

--- a/src/autoqasm/operators/arithmetic.py
+++ b/src/autoqasm/operators/arithmetic.py
@@ -26,11 +26,13 @@ def floor_div(
     den: aq_types.IntVar | aq_types.FloatVar | float,
 ) -> int | aq_types.IntVar:
     """Functional form of "//".
+
     Args:
-        num (IntVar | FloatVar | float) : The numerator of the integer division
-        den (IntVar | FloatVar | float) : The denominator of the integer division
-    Returns :
-        int | IntVar : integer division, IntVar if either numerator or denominator
+        num (IntVar | FloatVar | float): The numerator of the integer division
+        den (IntVar | FloatVar | float): The denominator of the integer division
+
+    Returns:
+        int | IntVar: integer division, IntVar if either numerator or denominator
         are QASM types, else int
     """
     if aq_types.is_qasm_type(num) or aq_types.is_qasm_type(den):

--- a/src/autoqasm/operators/control_flow.py
+++ b/src/autoqasm/operators/control_flow.py
@@ -22,7 +22,8 @@ from typing import Any
 import oqpy.base
 
 from autoqasm import program
-from autoqasm.types import GlobalQubitRegister, Range, is_qasm_type
+from autoqasm.types import Range, is_qasm_type
+from autoqasm.types.qubits import GlobalQubitRegister
 
 
 def for_stmt(

--- a/src/autoqasm/operators/control_flow.py
+++ b/src/autoqasm/operators/control_flow.py
@@ -22,11 +22,11 @@ from typing import Any
 import oqpy.base
 
 from autoqasm import program
-from autoqasm.types import Range, is_qasm_type
+from autoqasm.types import GlobalQubitRegister, Range, is_qasm_type
 
 
 def for_stmt(
-    iter: Iterable | oqpy.Range | oqpy.Qubit,
+    iter: Iterable | oqpy.Range,
     extra_test: Callable[[], Any] | None,
     body: Callable[[Any], None],
     get_state: Any,
@@ -37,7 +37,7 @@ def for_stmt(
     """Implements a for loop.
 
     Args:
-        iter (Iterable | Range | Qubit): The iterable to be looped over.
+        iter (Iterable | Range): The iterable to be looped over.
         extra_test (Callable[[], Any] | None): A function to cause the loop to break if true.
         body (Callable[[Any], None]): The body of the for loop.
         get_state (Any): Unused.
@@ -56,13 +56,13 @@ def for_stmt(
 
 
 def _oqpy_for_stmt(
-    iter: oqpy.Range | oqpy.Qubit,
+    iter: oqpy.Range | GlobalQubitRegister,
     body: Callable[[Any], None],
     opts: dict,
 ) -> None:
     """Overload of for_stmt that produces an oqpy for loop."""
     ctx = program.get_program_conversion_context()
-    if isinstance(iter, oqpy.Qubit):
+    if isinstance(iter, GlobalQubitRegister):
         iter = Range(iter.size)
 
     def _trace(ctx):

--- a/src/autoqasm/program/program.py
+++ b/src/autoqasm/program/program.py
@@ -20,7 +20,7 @@ __filter_from_traceback__ = True
 import contextlib
 import copy
 import threading
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any
@@ -39,9 +39,9 @@ from autoqasm.program.serialization_properties import (
     OpenQASMSerializationProperties,
     SerializationProperties,
 )
-from autoqasm.types import GlobalQubitRegister
 from autoqasm.types import QubitIdentifierType as Qubit
 from autoqasm.types.deferred import DeferredVarMixin
+from autoqasm.types.qubits import GlobalQubitRegister
 from braket.aws.aws_device import AwsDevice
 from braket.circuits.free_parameter_expression import FreeParameterExpression
 from braket.circuits.serialization import IRType, SerializableProgram
@@ -653,13 +653,13 @@ class ProgramConversionContext:
 
     def validate_gate_targets(
         self,
-        qubits: Iterable[Qubit],
+        qubits: Sequence[Qubit],
         angles: Iterable[Any],
     ) -> None:
         """Validate that the specified gate targets are valid at this point in the program.
 
         Args:
-            qubits (Iterable[QubitIdentifierType]): The target qubits to validate.
+            qubits (Sequence[Qubit]): The target qubits to validate.
             angles (Iterable[Any]): The target angles to validate.
 
         Raises:
@@ -669,9 +669,7 @@ class ProgramConversionContext:
         """
         for qubit in qubits:
             if not aq_types.is_qubit_identifier_type(qubit):
-                raise TypeError(
-                    f'Invalid qubit target: "{qubit}". Target must be a single qubit, not a list or a register.'
-                )
+                raise TypeError(f'Invalid qubit target: "{qubit}". Target must be a single qubit.')
 
         if self.in_verbatim_block and not self._gate_definitions_processing:
             self._validate_verbatim_target_qubits(qubits)
@@ -701,7 +699,7 @@ class ProgramConversionContext:
     def _normalize_gate_names(gate_names: Iterable[str]) -> list[str]:
         return [gate_name.lower() for gate_name in gate_names]
 
-    def _validate_verbatim_target_qubits(self, qubits: list[Any]) -> None:
+    def _validate_verbatim_target_qubits(self, qubits: Sequence[Qubit]) -> None:
         # Only physical target qubits are allowed in a verbatim block:
         for qubit in qubits:
             if not isinstance(qubit, str):

--- a/src/autoqasm/program/program.py
+++ b/src/autoqasm/program/program.py
@@ -663,14 +663,9 @@ class ProgramConversionContext:
             angles (Iterable[Any]): The target angles to validate.
 
         Raises:
-            TypeError: A target qubit is not a single qubit identifier.
             errors.InvalidTargetQubit: Target qubits are invalid in the current context.
             errors.InvalidGateDefinition: Targets are invalid in the current gate definition.
         """
-        for qubit in qubits:
-            if not aq_types.is_qubit_identifier_type(qubit):
-                raise TypeError(f'Invalid qubit target: "{qubit}". Target must be a single qubit.')
-
         if self.in_verbatim_block and not self._gate_definitions_processing:
             self._validate_verbatim_target_qubits(qubits)
 

--- a/src/autoqasm/program/program.py
+++ b/src/autoqasm/program/program.py
@@ -34,11 +34,12 @@ from sympy import Symbol
 
 import autoqasm.types as aq_types
 from autoqasm import _frame_filtering, constants, errors
-from autoqasm.instructions.qubits import GlobalQubitRegister, _get_physical_qubit_indices, _qubit
+from autoqasm.instructions.qubits import _get_physical_qubit_indices, _qubit
 from autoqasm.program.serialization_properties import (
     OpenQASMSerializationProperties,
     SerializationProperties,
 )
+from autoqasm.types import GlobalQubitRegister
 from autoqasm.types import QubitIdentifierType as Qubit
 from autoqasm.types.deferred import DeferredVarMixin
 from braket.aws.aws_device import AwsDevice
@@ -422,7 +423,7 @@ class ProgramConversionContext:
         """
         root_oqpy_program = self.get_oqpy_program(scope=ProgramScope.MAIN)
         self.global_qubit_register.size = size
-        root_oqpy_program.declare(self.global_qubit_register, to_beginning=True)
+        root_oqpy_program.declare(self.global_qubit_register.oqpy_var, to_beginning=True)
 
     def register_gate(self, gate_name: str, is_compiler_directive: bool = False) -> None:
         """Register a gate that is used in this program.
@@ -650,17 +651,28 @@ class ProgramConversionContext:
         oqpy_program = self.get_oqpy_program()
         return var_name in oqpy_program.declared_vars or var_name in oqpy_program.undeclared_vars
 
-    def validate_gate_targets(self, qubits: list[Any], angles: list[Any]) -> None:
+    def validate_gate_targets(
+        self,
+        qubits: Iterable[Qubit],
+        angles: Iterable[Any],
+    ) -> None:
         """Validate that the specified gate targets are valid at this point in the program.
 
         Args:
-            qubits (list[Any]): The list of target qubits to validate.
-            angles (list[Any]): The list of target angles to validate.
+            qubits (Iterable[QubitIdentifierType]): The target qubits to validate.
+            angles (Iterable[Any]): The target angles to validate.
 
         Raises:
+            TypeError: A target qubit is not a single qubit identifier.
             errors.InvalidTargetQubit: Target qubits are invalid in the current context.
             errors.InvalidGateDefinition: Targets are invalid in the current gate definition.
         """
+        for qubit in qubits:
+            if not aq_types.is_qubit_identifier_type(qubit):
+                raise TypeError(
+                    f'Invalid qubit target: "{qubit}". Target must be a single qubit, not a list or a register.'
+                )
+
         if self.in_verbatim_block and not self._gate_definitions_processing:
             self._validate_verbatim_target_qubits(qubits)
 

--- a/src/autoqasm/types/__init__.py
+++ b/src/autoqasm/types/__init__.py
@@ -16,15 +16,18 @@ for type handling.
 """
 
 from .conversions import map_parameter_type, var_type_from_oqpy, wrap_value  # noqa: F401
+from .qubits import (  # noqa: F401
+    GlobalQubitRegister,
+    QubitIdentifierType,
+    is_qubit_identifier_type,
+)
 from .types import (  # noqa: F401
     ArrayVar,
     BitVar,
     BoolVar,
     FloatVar,
     IntVar,
-    QubitIdentifierType,
     Range,
     is_qasm_type,
-    is_qubit_identifier_type,
     make_annotations_list,
 )

--- a/src/autoqasm/types/__init__.py
+++ b/src/autoqasm/types/__init__.py
@@ -16,11 +16,7 @@ for type handling.
 """
 
 from .conversions import map_parameter_type, var_type_from_oqpy, wrap_value  # noqa: F401
-from .qubits import (  # noqa: F401
-    GlobalQubitRegister,
-    QubitIdentifierType,
-    is_qubit_identifier_type,
-)
+from .qubits import QubitIdentifierType, is_qubit_identifier_type  # noqa: F401
 from .types import (  # noqa: F401
     ArrayVar,
     BitVar,

--- a/src/autoqasm/types/qubits.py
+++ b/src/autoqasm/types/qubits.py
@@ -21,11 +21,13 @@ from typing import Any, get_args
 import oqpy
 import oqpy.base
 
-from autoqasm import constants
+from autoqasm import constants, errors
 from braket.registers import Qubit
 
 QubitIdentifierType = int | str | Qubit | oqpy._ClassicalVar | oqpy.base.OQPyExpression | oqpy.Qubit
 
+# Precompute the type tuple once. get_args(QubitIdentifierType) is
+# an expensive operation and is called on every gate emission.
 _QUBIT_IDENTIFIER_TYPES: tuple[type, ...] = get_args(QubitIdentifierType)
 
 
@@ -77,14 +79,24 @@ class GlobalQubitRegister:
         return self._var
 
     def __repr__(self) -> str:
+        return f"{type(self).__name__}(name={self.name!r}, size={self.size!r})"
+
+    def __str__(self) -> str:
         return self.name
 
     def __len__(self) -> int:
+        if self.size is None:
+            raise errors.UnknownQubitCountError()
         return self.size
 
     def __iter__(self) -> Iterator[int]:
         return iter(range(len(self)))
 
     def __getitem__(self, index: int | str) -> oqpy.Qubit:
-        """Returns an oqpy.Qubit referring to ``__qubits__[index]``."""
+        """Returns an oqpy.Qubit referring to ``__qubits__[index]``.
+        ``index`` is either an integer index or a string containing
+        an already-serialized OpenQASM index expression.
+        """
+        if isinstance(index, bool) or not isinstance(index, (int, str)):
+            raise TypeError(f"invalid qubit register index: {index!r}")
         return oqpy.Qubit(f"{self.name}[{index}]", needs_declaration=False)

--- a/src/autoqasm/types/qubits.py
+++ b/src/autoqasm/types/qubits.py
@@ -1,0 +1,76 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+"""Qubit identifier types and the program-level qubit register."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any, get_args
+
+import oqpy
+import oqpy.base
+
+from autoqasm import constants
+from braket.registers import Qubit
+
+QubitIdentifierType = int | str | Qubit | oqpy._ClassicalVar | oqpy.base.OQPyExpression | oqpy.Qubit
+
+_QUBIT_IDENTIFIER_TYPES: tuple[type, ...] = get_args(QubitIdentifierType)
+
+
+def is_qubit_identifier_type(qubit: Any) -> bool:
+    """Checks if a given object is a qubit identifier type.
+
+    Args:
+        qubit (Any): The object to check.
+
+    Returns:
+        bool: True if the object is a qubit identifier type, False otherwise.
+    """
+    return isinstance(qubit, _QUBIT_IDENTIFIER_TYPES)
+
+
+class GlobalQubitRegister:
+    def __init__(self, size: int | None = None):
+        self._var = oqpy.Qubit(constants.QUBIT_REGISTER, size=size, needs_declaration=False)
+
+    @property
+    def name(self) -> str:
+        return self._var.name
+
+    @property
+    def size(self) -> int | None:
+        return self._var.size
+
+    @size.setter
+    def size(self, value: int) -> None:
+        self._var.size = value
+
+    @property
+    def oqpy_var(self) -> oqpy.Qubit:
+        """The underlying oqpy variable used to declare the register in OpenQASM."""
+        return self._var
+
+    def __repr__(self) -> str:
+        return self.name
+
+    def __len__(self) -> int:
+        return self.size
+
+    def __iter__(self) -> Iterator[int]:
+        return iter(range(len(self)))
+
+    def __getitem__(self, index: int | str) -> oqpy.Qubit:
+        """Returns an oqpy.Qubit referring to ``__qubits__[index]``."""
+        return oqpy.Qubit(f"{self.name}[{index}]", needs_declaration=False)

--- a/src/autoqasm/types/qubits.py
+++ b/src/autoqasm/types/qubits.py
@@ -15,7 +15,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from typing import Any, get_args
 
 import oqpy
@@ -39,6 +39,20 @@ def is_qubit_identifier_type(qubit: Any) -> bool:
         bool: True if the object is a qubit identifier type, False otherwise.
     """
     return isinstance(qubit, _QUBIT_IDENTIFIER_TYPES)
+
+
+def _as_qubit_iterable(
+    qubits: QubitIdentifierType | Iterable[QubitIdentifierType] | None,
+    default: Iterable[QubitIdentifierType] | None = None,
+) -> Iterable[QubitIdentifierType]:
+    """Normalize a qubit argument to an iterable. ``None`` maps to ``default`` (an empty
+    list if not provided); a single qubit identifier is wrapped in a list; iterables
+    (including :class:`GlobalQubitRegister`) pass through unchanged."""
+    if qubits is None:
+        qubits = default if default is not None else []
+    if is_qubit_identifier_type(qubits):
+        return [qubits]
+    return qubits
 
 
 class GlobalQubitRegister:

--- a/src/autoqasm/types/types.py
+++ b/src/autoqasm/types/types.py
@@ -16,7 +16,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import Any, get_args
+from typing import Any
 
 import numpy as np
 import oqpy
@@ -24,8 +24,8 @@ import oqpy.base
 from openpulse import ast
 
 from autoqasm import errors, program
+from autoqasm.types.qubits import GlobalQubitRegister
 from braket.circuits import FreeParameterExpression
-from braket.registers import Qubit
 
 
 def is_qasm_type(val: Any) -> bool:
@@ -44,6 +44,7 @@ def is_qasm_type(val: Any) -> bool:
         oqpy.Qubit,
         oqpy.base.OQPyExpression,
         FreeParameterExpression,
+        GlobalQubitRegister,
     )
     # The input can either be a class, like oqpy.Range ...
     if type(val) is type:
@@ -54,25 +55,6 @@ def is_qasm_type(val: Any) -> bool:
 
 def make_annotations_list(annotations: str | Iterable[str] | None) -> list[str]:
     return [annotations] if isinstance(annotations, str) else annotations or []
-
-
-QubitIdentifierType = int | str | Qubit | oqpy._ClassicalVar | oqpy.base.OQPyExpression | oqpy.Qubit
-
-# Precompute the type tuple once: ``get_args(QubitIdentifierType)`` isn't
-# free, and this is called on every gate emission.
-_QUBIT_IDENTIFIER_TYPES: tuple[type, ...] = get_args(QubitIdentifierType)
-
-
-def is_qubit_identifier_type(qubit: Any) -> bool:
-    """Checks if a given object is a qubit identifier type.
-
-    Args:
-        qubit (Any): The object to check.
-
-    Returns:
-        bool: True if the object is a qubit identifier type, False otherwise.
-    """
-    return isinstance(qubit, _QUBIT_IDENTIFIER_TYPES)
 
 
 class Range(oqpy.Range):

--- a/test/unit_tests/autoqasm/test_api.py
+++ b/test/unit_tests/autoqasm/test_api.py
@@ -23,8 +23,9 @@ import pytest
 import autoqasm as aq
 from autoqasm import errors
 from autoqasm.instructions import cnot, h, measure, rx, x
-from autoqasm.instructions.qubits import GlobalQubitRegister, _as_qubit_iterable
+from autoqasm.instructions.qubits import _as_qubit_iterable, _qubit
 from autoqasm.simulator import McmSimulator
+from autoqasm.types import GlobalQubitRegister
 from braket.devices import LocalSimulator
 from braket.tasks.local_quantum_task import LocalQuantumTask
 
@@ -697,8 +698,20 @@ def test_invalid_qubit_type_fails() -> None:
         """Uses invalid type for qubit index"""
         h(h)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         broken.build()
+
+
+def test_qubit_dispatch_rejects_float() -> None:
+    """Direct call to _qubit with a float hits the float singledispatch arm."""
+    with pytest.raises(TypeError, match="qubit index cannot be a float"):
+        _qubit(0.5)
+
+
+def test_qubit_dispatch_rejects_arbitrary_object() -> None:
+    """Direct call to _qubit with an unsupported type hits the default singledispatch arm."""
+    with pytest.raises(ValueError, match="invalid qubit label"):
+        _qubit(LocalSimulator())
 
 
 def test_bit_array_name() -> None:
@@ -1187,7 +1200,22 @@ def test_gate_register_not_allowed():
         h(aq.qubits)
 
     with pytest.raises(
-        ValueError, match="qubit index must be a single value, not a list or a register"
+        TypeError,
+        match=r'Invalid qubit target: "__qubits__"\. '
+        r"Target must be a single qubit, not a list or a register\.",
+    ):
+        main.build()
+
+
+def test_gate_list_not_allowed():
+    @aq.main(num_qubits=2)
+    def main():
+        h([0, 1])
+
+    with pytest.raises(
+        TypeError,
+        match=r'Invalid qubit target: "\[0, 1\]"\. '
+        r"Target must be a single qubit, not a list or a register\.",
     ):
         main.build()
 

--- a/test/unit_tests/autoqasm/test_api.py
+++ b/test/unit_tests/autoqasm/test_api.py
@@ -23,7 +23,6 @@ import pytest
 import autoqasm as aq
 from autoqasm import errors
 from autoqasm.instructions import cnot, h, measure, rx, x
-from autoqasm.instructions.qubits import _qubit
 from autoqasm.simulator import McmSimulator
 from autoqasm.types.qubits import GlobalQubitRegister, _as_qubit_iterable
 from braket.devices import LocalSimulator
@@ -674,7 +673,7 @@ def test_float_qubit_index_fails() -> None:
         i = 1
         h(i / 2)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(errors.InvalidQubitIdentifier):
         broken.build()
 
 
@@ -686,7 +685,11 @@ def test_bool_qubit_index_fails() -> None:
         """Uses invalid type for qubit index"""
         h(True)
 
-    with pytest.raises(TypeError, match="object of type 'bool' cannot be used as a qubit"):
+    with pytest.raises(
+        errors.InvalidQubitIdentifier,
+        match=r'Invalid qubit identifier: "True"\. Must be a single qubit, '
+        r"not an object of type 'bool'\.",
+    ):
         broken.build()
 
 
@@ -698,20 +701,8 @@ def test_invalid_qubit_type_fails() -> None:
         """Uses invalid type for qubit index"""
         h(h)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(errors.InvalidQubitIdentifier, match="not an object of type 'function'"):
         broken.build()
-
-
-def test_qubit_dispatch_rejects_float() -> None:
-    """Direct call to _qubit with a float hits the default singledispatch arm."""
-    with pytest.raises(TypeError, match="object of type 'float' cannot be used as a qubit"):
-        _qubit(0.5)
-
-
-def test_qubit_dispatch_rejects_arbitrary_object() -> None:
-    """Direct call to _qubit with an unsupported type hits the default singledispatch arm."""
-    with pytest.raises(TypeError, match="object of type 'complex' cannot be used as a qubit"):
-        _qubit(complex(1.2 + 3.4j))
 
 
 def test_bit_array_name() -> None:
@@ -1200,8 +1191,9 @@ def test_gate_register_not_allowed():
         h(aq.qubits)
 
     with pytest.raises(
-        TypeError,
-        match=r'Invalid qubit target: "__qubits__"\. Target must be a single qubit\.',
+        errors.InvalidQubitIdentifier,
+        match=r'Invalid qubit identifier: "__qubits__"\. Must be a single qubit, '
+        r"not an object of type 'GlobalQubitRegister'\.",
     ):
         main.build()
 
@@ -1212,8 +1204,9 @@ def test_gate_list_not_allowed():
         h([0, 1])
 
     with pytest.raises(
-        TypeError,
-        match=r'Invalid qubit target: "\[0, 1\]"\. Target must be a single qubit\.',
+        errors.InvalidQubitIdentifier,
+        match=r'Invalid qubit identifier: "\[0, 1\]"\. Must be a single qubit, '
+        r"not an object of type 'list'\.",
     ):
         main.build()
 
@@ -1224,8 +1217,9 @@ def test_gate_float_not_allowed():
         h(1.0)
 
     with pytest.raises(
-        TypeError,
-        match=r'Invalid qubit target: "1\.0"\. Target must be a single qubit\.',
+        errors.InvalidQubitIdentifier,
+        match=r'Invalid qubit identifier: "1\.0"\. Must be a single qubit, '
+        r"not an object of type 'float'\.",
     ):
         main.build()
 

--- a/test/unit_tests/autoqasm/test_api.py
+++ b/test/unit_tests/autoqasm/test_api.py
@@ -24,9 +24,8 @@ import autoqasm as aq
 from autoqasm import errors
 from autoqasm.instructions import cnot, h, measure, rx, x
 from autoqasm.instructions.qubits import _qubit
-from autoqasm.types.qubits import _as_qubit_iterable
 from autoqasm.simulator import McmSimulator
-from autoqasm.types import GlobalQubitRegister
+from autoqasm.types.qubits import GlobalQubitRegister, _as_qubit_iterable
 from braket.devices import LocalSimulator
 from braket.tasks.local_quantum_task import LocalQuantumTask
 
@@ -704,7 +703,7 @@ def test_invalid_qubit_type_fails() -> None:
 
 
 def test_qubit_dispatch_rejects_float() -> None:
-    """Direct call to _qubit with a float hits the float singledispatch arm."""
+    """Direct call to _qubit with a float hits the default singledispatch arm."""
     with pytest.raises(TypeError, match="object of type 'float' cannot be used as a qubit"):
         _qubit(0.5)
 
@@ -1202,8 +1201,7 @@ def test_gate_register_not_allowed():
 
     with pytest.raises(
         TypeError,
-        match=r'Invalid qubit target: "__qubits__"\. '
-        r"Target must be a single qubit, not a list or a register\.",
+        match=r'Invalid qubit target: "__qubits__"\. Target must be a single qubit\.',
     ):
         main.build()
 
@@ -1215,10 +1213,41 @@ def test_gate_list_not_allowed():
 
     with pytest.raises(
         TypeError,
-        match=r'Invalid qubit target: "\[0, 1\]"\. '
-        r"Target must be a single qubit, not a list or a register\.",
+        match=r'Invalid qubit target: "\[0, 1\]"\. Target must be a single qubit\.',
     ):
         main.build()
+
+
+def test_gate_float_not_allowed():
+    @aq.main(num_qubits=2)
+    def main():
+        h(1.0)
+
+    with pytest.raises(
+        TypeError,
+        match=r'Invalid qubit target: "1\.0"\. Target must be a single qubit\.',
+    ):
+        main.build()
+
+
+def test_gate_register_slice_not_allowed():
+    @aq.main(num_qubits=4)
+    def main():
+        h(aq.qubits[0:2])
+
+    with pytest.raises(TypeError, match="invalid qubit register index"):
+        main.build()
+
+
+def test_global_qubit_register_len_needs_num_qubits():
+    with pytest.raises(errors.UnknownQubitCountError):
+        len(GlobalQubitRegister())
+
+
+def test_global_qubit_register_repr_and_str():
+    register = GlobalQubitRegister(size=3)
+    assert str(register) == "__qubits__"
+    assert repr(register) == "GlobalQubitRegister(name='__qubits__', size=3)"
 
 
 def test_global_qubit_register_loop():

--- a/test/unit_tests/autoqasm/test_api.py
+++ b/test/unit_tests/autoqasm/test_api.py
@@ -687,7 +687,7 @@ def test_bool_qubit_index_fails() -> None:
         """Uses invalid type for qubit index"""
         h(True)
 
-    with pytest.raises(TypeError, match="qubit index cannot be a bool"):
+    with pytest.raises(TypeError, match="object of type 'bool' cannot be used as a qubit"):
         broken.build()
 
 
@@ -705,7 +705,7 @@ def test_invalid_qubit_type_fails() -> None:
 
 def test_qubit_dispatch_rejects_float() -> None:
     """Direct call to _qubit with a float hits the float singledispatch arm."""
-    with pytest.raises(TypeError, match="qubit index cannot be a float"):
+    with pytest.raises(TypeError, match="object of type 'float' cannot be used as a qubit"):
         _qubit(0.5)
 
 

--- a/test/unit_tests/autoqasm/test_api.py
+++ b/test/unit_tests/autoqasm/test_api.py
@@ -687,7 +687,7 @@ def test_bool_qubit_index_fails() -> None:
         """Uses invalid type for qubit index"""
         h(True)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError, match="qubit index cannot be a bool"):
         broken.build()
 
 
@@ -711,8 +711,8 @@ def test_qubit_dispatch_rejects_float() -> None:
 
 def test_qubit_dispatch_rejects_arbitrary_object() -> None:
     """Direct call to _qubit with an unsupported type hits the default singledispatch arm."""
-    with pytest.raises(ValueError, match="invalid qubit label"):
-        _qubit(LocalSimulator())
+    with pytest.raises(TypeError, match="object of type 'complex' cannot be used as a qubit"):
+        _qubit(complex(1.2 + 3.4j))
 
 
 def test_bit_array_name() -> None:

--- a/test/unit_tests/autoqasm/test_api.py
+++ b/test/unit_tests/autoqasm/test_api.py
@@ -23,7 +23,8 @@ import pytest
 import autoqasm as aq
 from autoqasm import errors
 from autoqasm.instructions import cnot, h, measure, rx, x
-from autoqasm.instructions.qubits import _as_qubit_iterable, _qubit
+from autoqasm.instructions.qubits import _qubit
+from autoqasm.types.qubits import _as_qubit_iterable
 from autoqasm.simulator import McmSimulator
 from autoqasm.types import GlobalQubitRegister
 from braket.devices import LocalSimulator

--- a/test/unit_tests/autoqasm/test_gate_decorator.py
+++ b/test/unit_tests/autoqasm/test_gate_decorator.py
@@ -173,7 +173,7 @@ def test_incorrect_arg_types() -> None:
     def incorrect_arg_types():
         my_gate(0.25, 0)
 
-    with pytest.raises(TypeError):
+    with pytest.raises(errors.InvalidQubitIdentifier):
         incorrect_arg_types.build()
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Cleans up `GlobalQubitRegister` to properly encapsulate its usage of `oqpy.Qubit`. Moves qubit-related type definitions into a new submodule under `types` and unifies qubit identifier validation to return a new error type `InvalidQubitIdentifier`.

*Testing done:*

tox passes, new tests added & existing tests updated.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/autoqasm/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/autoqasm/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/autoqasm/blob/main/README.md) and [API docs](https://github.com/amazon-braket/autoqasm/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
